### PR TITLE
tags: standardize frontmatter tags for all Portuguese posts

### DIFF
--- a/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -3,8 +3,11 @@ title: 'ESPBoy: A Gameboy with ESP32'
 description: Just another Gameboy made with ESP32
 date: '2019-01-03 01:00:00'
 tags:
-  - DIY
   - EN_US
+  - DIY
+  - gaming
+  - embedded
+  - esp32
 ---
 
 # Specification:

--- a/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -195,3 +195,9 @@ I used the online circuit and PCB development software [EasyEDA](https://easyeda
 The result can be seen in the image below:
 
 ![ESPBoy-PCB](https://i.imgur.com/mkLqXRc.jpg)
+
+## See also
+
+- [[Que-tal-criar-um-jogo]] — my journey learning game development
+- [[tetris-game]] — Tetris in C++ with SDL2 and WebAssembly
+- [[glossary]] — terms like ESP32, TFT, GPIO, PAM8403, TP4056, SD Card

--- a/content/en/posts/Que-tal-criar-um-jogo.md
+++ b/content/en/posts/Que-tal-criar-um-jogo.md
@@ -168,3 +168,9 @@ See you soon!!!
 
 
 [Godot]: https://godotengine.org/
+
+## See also
+
+- [[ESPBoy-A-ESP32-Gameboy|ESPBoy]] — a homemade Gameboy with ESP32
+- [[pong]] — my first game in C, Pong with SDL2
+- [[glossary]] — terms like SDL2, Godot, GDNative, FOSS, Nuklear, LVGL

--- a/content/en/posts/Que-tal-criar-um-jogo.md
+++ b/content/en/posts/Que-tal-criar-um-jogo.md
@@ -4,6 +4,7 @@ description: ''
 date: '2022-05-09 16:30:33'
 tags:
   - EN_US
+  - gaming
 ---
 
 # How about making a game?

--- a/content/en/posts/em-busca-de-uma-interface-git.md
+++ b/content/en/posts/em-busca-de-uma-interface-git.md
@@ -2,7 +2,10 @@
 title: In Search of a Self-Hosted Git Interface
 description: ''
 date: '2022-02-28 00:02:23'
-tags: [EN_US]
+tags:
+  - EN_US
+  - self-hosting
+  - git
 ---
 
 # In Search of a Self-Hosted Git Interface

--- a/content/en/posts/em-busca-de-uma-interface-git.md
+++ b/content/en/posts/em-busca-de-uma-interface-git.md
@@ -108,3 +108,9 @@ By reading the `git` and [cgit] documentation, I was able to host a simple and l
 [suckless]: https://suckless.org/
 [stagi]: https://git.codemadness.org/stagit/file/README.html
 [git-mirror]: https://github.com/janbaudisch/git-mirror
+
+## See also
+
+- [[servidor-de-email-privado]] — self-hosted email server with Yunohost
+- [[migrando-do-gitlab-para-o-github]] — migrating repositories from Gitlab to Github
+- [[glossary]] — terms like self-hosted, VPS, CGI, cgit, stagit, Suckless

--- a/content/en/posts/fix_zsh_corrupt_history.md
+++ b/content/en/posts/fix_zsh_corrupt_history.md
@@ -4,6 +4,7 @@ description: How to fix a corrupted zsh history file
 date: '2021-04-17 18:04:26'
 tags:
   - EN_US
+  - shell
 ---
 
 ## How to fix a corrupted ZSH history

--- a/content/en/posts/how_to_play_like_johnny_ramone.md
+++ b/content/en/posts/how_to_play_like_johnny_ramone.md
@@ -4,6 +4,8 @@ description: ''
 date: '2021-04-17 18:04:26'
 tags:
   - EN_US
+  - guitar
+  - ramones
 ---
 
 ## How to play guitar like Johnny Ramone

--- a/content/en/posts/how_to_play_like_johnny_ramone.md
+++ b/content/en/posts/how_to_play_like_johnny_ramone.md
@@ -45,3 +45,8 @@ Another interesting channel is [Hardly Ramone](https://www.youtube.com/channel/U
   * [Bass Habits - Ep 9 - How to sound like Dee Dee Ramone](https://www.youtube.com/watch?v=vC6-AvpIJ5I)
 * Imgur
   * [Johnny Ramone - Power Chords](https://i.imgur.com/JfjIc9G.jpg)
+
+## See also
+
+- [[zuko-pedal-marshall-diy]] — my DIY open hardware Marshall Plexi pedal
+- [[glossary]] — terms like Downstrokes, Mosrite, Bridge pickup

--- a/content/en/posts/menos-e-mais-i18n-kiss.md
+++ b/content/en/posts/menos-e-mais-i18n-kiss.md
@@ -3,9 +3,10 @@ title: "Less is more: refactoring the blog's i18n with KISS and Unix philosophy"
 description: "I swapped flag emojis for a globe icon, moved 28 files around, and generated automatic redirects — all without a framework, without an i18n library, and without unnecessary JavaScript."
 date: "2026-08-01 00:00:00"
 tags:
+  - EN_US
+  - blog
   - suckless
-  - web
-  - quartz
+  - i18n
 ---
 
 # Less is more: refactoring the blog's i18n with KISS and Unix philosophy

--- a/content/en/posts/menos-e-mais-i18n-kiss.md
+++ b/content/en/posts/menos-e-mais-i18n-kiss.md
@@ -199,4 +199,8 @@ This site has 139 static files, 52 Markdown files, and zero runtime dependencies
 
 ---
 
-This post is part of the blog's behind-the-scenes series. If you're into this philosophy, check out the [source code](https://github.com/Calebe94/blog) and the [glossary](/en/notes/glossary) — it's updated with every post.
+This post is part of the blog's behind-the-scenes series. If you're into this philosophy, check out the [source code](https://github.com/Calebe94/blog) and the [[glossary]] — it's updated with every post.
+
+## See also
+
+- [[premissas_basicas]] — fundamental premises: Unix and Suckless philosophy

--- a/content/en/posts/migrando-do-gitlab-para-o-github.md
+++ b/content/en/posts/migrando-do-gitlab-para-o-github.md
@@ -4,6 +4,8 @@ description: ''
 date: '2022-05-30 16:48:12'
 tags:
   - EN_US
+  - self-hosting
+  - git
 ---
 
 Migrating repositories from Gitlab to Github {#migrando-do-gitlab-para-o-github-1}

--- a/content/en/posts/migrando-do-gitlab-para-o-github.md
+++ b/content/en/posts/migrando-do-gitlab-para-o-github.md
@@ -71,3 +71,8 @@ any information in the process.
 
 All projects that had *issues* and *Merge Requests* were successfully
 imported to **Github**.
+
+## See also
+
+- [[em-busca-de-uma-interface-git]] — my search for a self-hosted git interface
+- [[glossary]] — terms like Merge Request, Pull Request, VPS

--- a/content/en/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/en/posts/organizacao-de-um-projeto-em-c.md
@@ -4,6 +4,7 @@ description: ''
 date: '2023-02-23 20:50:26'
 tags:
   - EN_US
+  - c
 ---
 
 # Organizing a C project

--- a/content/en/posts/pong-em-c-sdl2.md
+++ b/content/en/posts/pong-em-c-sdl2.md
@@ -3,8 +3,10 @@ title: Building the Classic Pong in C with SDL2
 description: ''
 date: '2023-08-21 21:00:00'
 tags:
-  - DIY
   - EN_US
+  - gaming
+  - c
+  - sdl2
 ---
 
 # Building the Classic Pong in C with SDL2

--- a/content/en/posts/pong-em-c-sdl2.md
+++ b/content/en/posts/pong-em-c-sdl2.md
@@ -37,3 +37,9 @@ One of the most exciting parts of building your own game is making it yours. Onc
 # Conclusion
 
 Building Pong in C with SDL2 is an exciting way to dive into game development. With the foundation provided in the [repository](https://github.com/Calebe94/sdl2-pong), you can explore the fundamentals behind Pong and eventually expand and customize the game to match your creative vision. So roll up your sleeves and start your game development journey!
+
+## See also
+
+- [[pong]] — my first game in C, the original Pong
+- [[tetris-game]] — Tetris in C++ with SDL2 and WebAssembly
+- [[glossary]] — terms like SDL2, game loop

--- a/content/en/posts/pong.md
+++ b/content/en/posts/pong.md
@@ -3,9 +3,10 @@ title: My first game in C
 description: Pong in SDL2
 date: '2022-05-19 21:19:33'
 tags:
-  - pong
-  - C
   - EN_US
+  - gaming
+  - c
+  - sdl2
 ---
 
 My first game in C

--- a/content/en/posts/pong.md
+++ b/content/en/posts/pong.md
@@ -12,7 +12,7 @@ tags:
 My first game in C
 ======================
 
-As I mentioned in the [previous post](https://blog.calebe.dev.br/posts/Que-tal-criar-um-jogo.html),
+As I mentioned in the [[Que-tal-criar-um-jogo|previous post]],
 I'm planning to create a game in **C** using the **SDL2** library.
 
 So to "get the hang of" how to build a game with **SDL2**,
@@ -33,3 +33,9 @@ I also plan to create a web demo of the game, using Web Assembly.
 Well... that's it for now.
 
 See you next time!
+
+## See also
+
+- [[pong-em-c-sdl2]] — the detailed Pong in C with SDL2
+- [[tetris-game]] — Tetris in C++ with SDL2 and WebAssembly
+- [[glossary]] — terms like SDL2, WebAssembly

--- a/content/en/posts/premissas_basicas.md
+++ b/content/en/posts/premissas_basicas.md
@@ -4,6 +4,7 @@ description: ''
 date: '2021-04-17 18:04:26'
 tags:
   - EN_US
+  - suckless
 ---
 
 <main>

--- a/content/en/posts/premissas_basicas.md
+++ b/content/en/posts/premissas_basicas.md
@@ -70,4 +70,10 @@ The fewer lines of code your code has, the more skilled you have become, and the
 [Unix Philosophy]: http://www.linfo.org/unix_philosophy.html
 [Suckless Philosophy]: https://suckless.org/philosophy/
 [TL:DR]: https://www.lifewire.com/what-is-tldr-2483633
+
+## See also
+
+- [[tinytoolsh-ferramentas-minuculas-para-produtividade|tinytoolsh]] — tiny tools for productivity
+- [[menos-e-mais-i18n-kiss]] — refactoring the blog i18n with KISS and Unix philosophy
+- [[glossary]] — terms like Suckless
 </main>

--- a/content/en/posts/servidor-de-email-privado.md
+++ b/content/en/posts/servidor-de-email-privado.md
@@ -12,7 +12,7 @@ tags:
 
 ### `The saga of frustration`
 
-As I mentioned in a [previous post](./em-busca-de-uma-interface-git.html), I have a [Yunohost] instance running on my VPS. [Yunohost] makes it incredibly easy to install your "web" apps on your server and comes with some handy tools to manage everything. One of those tools is the email server, which notifies you if any errors occur during server diagnostics.
+As I mentioned in a [[em-busca-de-uma-interface-git|previous post]], I have a [Yunohost] instance running on my VPS. [Yunohost] makes it incredibly easy to install your "web" apps on your server and comes with some handy tools to manage everything. One of those tools is the email server, which notifies you if any errors occur during server diagnostics.
 
 You can also set up email forwarding. Users can register a few email addresses on the platform, and whenever an email arrives, `postfix` takes care of delivering it to the user's personal account.
 
@@ -78,3 +78,8 @@ So that's what I'll be researching over the next few weeks, and I'll document th
 [Twillio]: https://www.twillio.com
 [Yunohost]: yunohost.org
 [Digital Ocean]: https://www.digitalocean.com/
+
+## See also
+
+- [[em-busca-de-uma-interface-git]] — my search for a self-hosted git interface
+- [[glossary]] — terms like Yunohost, VPS, Postfix, SMTP Relay, SendGrid

--- a/content/en/posts/servidor-de-email-privado.md
+++ b/content/en/posts/servidor-de-email-privado.md
@@ -4,6 +4,8 @@ description: ''
 date: '2022-03-01 22:21:33'
 tags:
   - EN_US
+  - self-hosting
+  - email
 ---
 
 # Self-hosted email server

--- a/content/en/posts/tcc-tools.md
+++ b/content/en/posts/tcc-tools.md
@@ -4,6 +4,8 @@ description: ''
 date: '2023-09-05 13:00:00'
 tags:
   - EN_US
+  - tcc
+  - compression
 ---
 
 # Essential Tools for Developing Your Final Year Project 🛠️📚

--- a/content/en/posts/tcc-tools.md
+++ b/content/en/posts/tcc-tools.md
@@ -45,3 +45,8 @@ The journey of creating your Final Year Project (TCC — Trabalho de Conclusão 
 **16. [Perplexity.ai](https://www.perplexity.ai/) (Writing Assistance) 📝✨:** For advanced assistance in writing your project, Perplexity.ai is a powerful tool that offers support in text generation, review, and creating quality content.
 
 These tools can make your journey of developing your final year project easier, saving time and ensuring the quality of your work. Choose the ones that best suit your needs and preferences. Good luck with your research and your project! 🌟🎓
+
+## See also
+
+- [[tcc]] — data compression techniques on IoT devices
+- [[glossary]] — terms like IoT, TCC

--- a/content/en/posts/tcc.md
+++ b/content/en/posts/tcc.md
@@ -4,12 +4,8 @@ description: >-
   Unveiling the Efficiency of Data Compression Techniques in IoT Devices
 date: '2023-09-05 11:00:00'
 tags:
-  - DIY
   - EN_US
-  - iot
-  - data
-  - compression
-  - final paper
+  - tcc
 ---
 
 # Unveiling the Efficiency of Data Compression Techniques in IoT Devices

--- a/content/en/posts/tcc.md
+++ b/content/en/posts/tcc.md
@@ -63,3 +63,8 @@ Finally, I will present my TCC and defend it before an academic panel.
 # Conclusion
 
 This is the path I have traveled so far and what is yet to come in my TCC journey on data compression in IoT. This is an exciting and constantly evolving field, and I am eager to contribute new knowledge that can benefit the world of technology. Stay tuned for further updates as we progress on this journey!
+
+## See also
+
+- [[tcc-tools]] — essential tools for developing the TCC
+- [[glossary]] — terms like IoT, compression

--- a/content/en/posts/teclado-appa.md
+++ b/content/en/posts/teclado-appa.md
@@ -3,12 +3,10 @@ title: APPA Keyboard
 description: Mechanical keyboard with ALPS switches inspired by the plaid
 date: '2023-02-23 16:00:00'
 tags:
-  - DIY
   - EN_US
-  - Mechanical Keyboards
+  - DIY
   - keyboards
   - qmk
-  - appa
 ---
 
 # APPA Keyboard

--- a/content/en/posts/teclado-appa.md
+++ b/content/en/posts/teclado-appa.md
@@ -51,7 +51,7 @@ I chose this name as a tribute to [Appa](https://avatar.fandom.com/wiki/Appa), a
 <img src="https://cdn11.bigcommerce.com/s-5242sis1by/images/stencil/2560w/products/282/1043/Appa__86978.1595902634.png" width="50%">
 </center>
 
-Since I had already decided to use [ALPS] switches in the project, I chose the name **Appa** because it starts with the letter "**A**". And I'll name a future keyboard project with [Cherry MX] switches **Momo**.
+Since I had already decided to use [ALPS] switches in the project, I chose the name **Appa** because it starts with the letter "**A**". And I'll name a future keyboard project with [Cherry MX] switches **Momo** — see [[teclado-momo]].
 
 ## Case Design
 
@@ -338,3 +338,8 @@ Finally, here's a video summarizing the assembly of the [Appa]:
 [Gertec]: https://www.gertec.com.br/
 [Mercado Livre]: https://www.mercadolivre.com.br/
 [QMK no Discord]: https://discord.com/invite/Uq7gcHh
+
+## See also
+
+- [[teclado-momo]] — the Cherry MX keyboard, Appa's successor
+- [[glossary]] — terms like QMK, ALPS, Cherry MX, USBaspLoader, WS2812B

--- a/content/en/posts/teclado-momo.md
+++ b/content/en/posts/teclado-momo.md
@@ -3,12 +3,10 @@ title: MOMO Keyboard
 description: Mechanical keyboard with hotswap and RGB
 date: '2023-09-23 16:00:00'
 tags:
-  - DIY
   - EN_US
-  - Mechanical-Keyboards
+  - DIY
   - keyboards
   - qmk
-  - momo
 ---
 
 # My Journey Building the Momo Mechanical Keyboard

--- a/content/en/posts/teclado-momo.md
+++ b/content/en/posts/teclado-momo.md
@@ -20,7 +20,7 @@ If you've ever stopped to think about the importance of the keyboard you use eve
 For many of us, a keyboard is much more than just a peripheral; it's an extension of our creativity and productivity, and every keystroke can be a unique experience.
 
 If you're a tech enthusiast looking for a customization adventure, building a mechanical keyboard is a fascinating journey.
-Recently, I shared the story behind my **Appa** keyboard, which uses Alps switches, in a [previous post](./teclado-appa.html).
+Recently, I shared the story behind my **Appa** keyboard, which uses Alps switches, in a [[teclado-appa|previous post]].
 
 Now, let's dive into the creation of the **Momo** mechanical keyboard, which, although inspired by "Appa," brings its own unique characteristics.
 This keyboard uses Cherry MX switches, features hotswap, and is a tribute to [Aang's](https://avatar.fandom.com/wiki/Aang) adorable pet, **Momo**.
@@ -154,4 +154,9 @@ This is just the beginning of my creative exploration and passion for technology
 As you dive deeper into the world of keyboard customization, you'll discover a vibrant community of enthusiasts who share the same passion.
 So, if you're ready for a customization adventure, go ahead and start planning your own mechanical keyboard. Remember to share your journey with other enthusiasts and inspire new creations. Who knows, you might create the next amazing keyboard everyone wants to have!
 
-If you'd like to learn more about the process of building custom mechanical keyboards, also check out my [previous post](./teclado-appa.html), which offers additional insights.
+If you'd like to learn more about the process of building custom mechanical keyboards, also check out my [[teclado-appa|previous post]], which offers additional insights.
+
+## See also
+
+- [[teclado-appa]] — the ALPS keyboard that inspired Momo
+- [[glossary]] — terms like QMK, hotswap, underglow, backlight, RP2040, WS2812B, SK6812

--- a/content/en/posts/terminal-animation.md
+++ b/content/en/posts/terminal-animation.md
@@ -4,9 +4,9 @@ description: A Step-by-Step Guide
 date: '2023-09-15 16:00:00'
 tags:
   - EN_US
-  - CSS
+  - blog
+  - shell
   - animation
-  - HTML5
 ---
 
 # Creating a Terminal-Style CSS Animation

--- a/content/en/posts/terminal-animation.md
+++ b/content/en/posts/terminal-animation.md
@@ -163,3 +163,7 @@ Web development is all about creativity, and little details like this can make y
 ---
 
 Feel free to adapt this post to your site, add more details, and include any additional insights or challenges you faced while creating your terminal-style animation. Good luck!
+
+## See also
+
+- [[glossary]] — terms like Keyframe, @keyframes, Typewriter effect, Prompt

--- a/content/en/posts/tetris-game.md
+++ b/content/en/posts/tetris-game.md
@@ -138,3 +138,10 @@ Building a Tetris game in C++ and SDL2 is a rewarding journey that covers variou
 Stay tuned for future updates as I improve our Tetris game and explore even more game development concepts. I hope this journey has inspired you to embark on your own game development adventure!
 
 Remember that you can try out the Tetris game both on the desktop and on the web, thanks to the power of WebAssembly. The complete game source code is available at [https://github.com/calebe94/tetris](https://github.com/calebe94/tetris), and you can play it at [https://blog.calebe.dev.br/tetris/](https://blog.calebe.dev.br/tetris/). Have fun playing and exploring the world of game development!
+
+## See also
+
+- [[pong]] — my first game in C, the original Pong
+- [[pong-em-c-sdl2]] — the detailed Pong in C with SDL2
+- [[ESPBoy-A-ESP32-Gameboy|ESPBoy]] — a homemade Gameboy with ESP32
+- [[glossary]] — terms like SDL2, WebAssembly, Tetromino, Dear ImGui, Emscripten

--- a/content/en/posts/tetris-game.md
+++ b/content/en/posts/tetris-game.md
@@ -3,8 +3,9 @@ title: Building Tetris in C++ with SDL2 and WebAssembly
 description: ''
 date: '2023-09-10 18:00:00'
 tags:
-  - DIY
   - EN_US
+  - gaming
+  - c
 ---
 
 # 🎮 Building Tetris in C++ with SDL2 and WebAssembly 🚀

--- a/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -130,3 +130,8 @@ If you're into the Unix philosophy of small tools that work well together, check
 And if you want to contribute, all tools are under [GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html). There are open `issue`s across several repositories.
 
 See you next time!!!
+
+## See also
+
+- [[premissas_basicas]] — fundamental premises: Unix and Suckless philosophy
+- [[glossary]] — terms like Suckless, dmenu, systemd, journalctl

--- a/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -4,10 +4,8 @@ description: "How a shell scripts project grew and became a GitHub organization"
 date: "2026-07-17 23:00:00"
 tags:
   - EN_US
-  - DIY
-  - shell
   - suckless
-  - FOSS
+  - shell
 ---
 
 # TinyToolSH: Tiny tools to boost your productivity

--- a/content/en/posts/zuko-pedal-marshall-diy.md
+++ b/content/en/posts/zuko-pedal-marshall-diy.md
@@ -300,7 +300,7 @@ Gabba Gabba Hey!
 
 ## Glossary
 
-This post uses several terms from guitar, electronics, and digital audio. If any are unfamiliar, check the [blog glossary](/en/notes/glossary) — it's updated with every post.
+This post uses several terms from guitar, electronics, and digital audio. If any are unfamiliar, check the [[glossary]] — it's updated with every post.
 
 The main terms used here:
 
@@ -314,7 +314,11 @@ The main terms used here:
 | **mu-amp** | 2-JFET configuration that emulates power amp push-pull |
 | **Scooped mids** | Mid frequencies attenuated — that "hollow" aggressive sound |
 
-Full glossary with all terms: [/en/notes/glossary](/en/notes/glossary).
+Full glossary with all terms: [[glossary]].
+
+## See also
+
+- [[how_to_play_like_johnny_ramone]] — how to play guitar like Johnny Ramone
 
 ## References
 

--- a/content/en/posts/zuko-pedal-marshall-diy.md
+++ b/content/en/posts/zuko-pedal-marshall-diy.md
@@ -7,7 +7,6 @@ tags:
   - DIY
   - guitar
   - open-hardware
-  - ramones
 ---
 
 # Zuko: a DIY open hardware Marshall Plexi pedal

--- a/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -3,8 +3,11 @@ title: 'ESPBoy: Um Gameboy com o ESP32'
 description: Apenas mais um Gameboy feito com o ESP32
 date: '2019-01-03 01:00:00'
 tags:
-  - DIY
   - PT_BR
+  - DIY
+  - gaming
+  - embedded
+  - esp32
 ---
 
 # Especificação:

--- a/content/pt/posts/Que-tal-criar-um-jogo.md
+++ b/content/pt/posts/Que-tal-criar-um-jogo.md
@@ -2,7 +2,9 @@
 title: Que tal criar um jogo?
 description: ''
 date: '2022-05-09 16:30:33'
-tags: []
+tags:
+  - PT_BR
+  - gaming
 ---
 
 # Que tal criar um jogo?

--- a/content/pt/posts/construindo-um-teclado-mecanico.md
+++ b/content/pt/posts/construindo-um-teclado-mecanico.md
@@ -3,8 +3,10 @@ title: Construindo seu próprio teclado mecânico do zero
 description: Etapas para criação de um teclado mecânico
 date: '2023-02-23 21:00:00'
 tags:
-  - DIY
   - PT_BR
+  - DIY
+  - keyboards
+  - qmk
 ---
 
 # Construindo seu próprio teclado mecânico do zero

--- a/content/pt/posts/em-busca-de-uma-interface-git.md
+++ b/content/pt/posts/em-busca-de-uma-interface-git.md
@@ -2,7 +2,10 @@
 title: Em busca de uma interface git self-hosted
 description: ''
 date: '2022-02-28 00:02:23'
-tags: []
+tags:
+  - PT_BR
+  - self-hosting
+  - git
 ---
 
 # Em busca de uma interface git self-hosted

--- a/content/pt/posts/fix_zsh_corrupt_history.md
+++ b/content/pt/posts/fix_zsh_corrupt_history.md
@@ -2,7 +2,9 @@
 title: Resolvendo historico corrompido do ZSH
 description: Como resolver o problema de historico corrompido do zsh
 date: '2021-04-17 18:04:26'
-tags: []
+tags:
+  - PT_BR
+  - shell
 ---
 
 ## Como resolver o problema de historico corrompido do zsh

--- a/content/pt/posts/how_to_play_like_johnny_ramone.md
+++ b/content/pt/posts/how_to_play_like_johnny_ramone.md
@@ -2,7 +2,10 @@
 title: Como tocar guitarra como johnny Ramone
 description: ''
 date: '2021-04-17 18:04:26'
-tags: []
+tags:
+  - PT_BR
+  - guitar
+  - ramones
 ---
 
 ## Como tocar guitarra como Johnny Ramone

--- a/content/pt/posts/menos-e-mais-i18n-kiss.md
+++ b/content/pt/posts/menos-e-mais-i18n-kiss.md
@@ -4,9 +4,9 @@ description: "Troquei bandeirinhas por um ícone de globo, movi 28 arquivos de l
 date: "2026-08-01 00:00:00"
 tags:
   - PT_BR
+  - blog
   - suckless
-  - web
-  - quartz
+  - i18n
 ---
 
 # Menos é mais: refatorando o i18n do blog com KISS e filosofia Unix

--- a/content/pt/posts/migrando-do-gitlab-para-o-github.md
+++ b/content/pt/posts/migrando-do-gitlab-para-o-github.md
@@ -2,7 +2,10 @@
 title: Migrando repositórios do Gitlab para o Github
 description: ''
 date: '2022-05-30 16:48:12'
-tags: []
+tags:
+  - PT_BR
+  - self-hosting
+  - git
 ---
 
 Migrando repositórios do Gitlab para o Github {#migrando-do-gitlab-para-o-github-1}

--- a/content/pt/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/pt/posts/organizacao-de-um-projeto-em-c.md
@@ -2,7 +2,9 @@
 title: Organização de projeto em C
 description: ''
 date: '2023-02-23 20:50:26'
-tags: []
+tags:
+  - PT_BR
+  - c
 ---
 
 # Organização de projeto em C

--- a/content/pt/posts/pong-em-c-sdl2.md
+++ b/content/pt/posts/pong-em-c-sdl2.md
@@ -3,8 +3,10 @@ title: Desenvolvendo o Clássico Pong em C com a Biblioteca SDL2
 description: ''
 date: '2023-08-21 21:00:00'
 tags:
-  - DIY
   - PT_BR
+  - gaming
+  - c
+  - sdl2
 ---
 
 # Desenvolvendo o Clássico Pong em C com a Biblioteca SDL2

--- a/content/pt/posts/pong.md
+++ b/content/pt/posts/pong.md
@@ -3,9 +3,10 @@ title: Meu primeiro jogo em C
 description: Pong em SDL2
 date: '2022-05-19 21:19:33'
 tags:
-  - pong
-  - C
-  - SDL2
+  - PT_BR
+  - gaming
+  - c
+  - sdl2
 ---
 
 Meu primeiro jogo em C

--- a/content/pt/posts/premissas_basicas.md
+++ b/content/pt/posts/premissas_basicas.md
@@ -2,7 +2,9 @@
 title: Premissas básicas de desenvolvimento - Suckless
 description: ''
 date: '2021-04-17 18:04:26'
-tags: []
+tags:
+  - PT_BR
+  - suckless
 ---
 
 <main>

--- a/content/pt/posts/servidor-de-email-privado.md
+++ b/content/pt/posts/servidor-de-email-privado.md
@@ -2,7 +2,10 @@
 title: Servidor de email (self-hosted)
 description: ''
 date: '2022-03-01 22:21:33'
-tags: []
+tags:
+  - PT_BR
+  - self-hosting
+  - email
 ---
 
 # Servidor de email (self-hosted)

--- a/content/pt/posts/tcc-tools.md
+++ b/content/pt/posts/tcc-tools.md
@@ -2,7 +2,10 @@
 title: Ferramentas Essenciais para o Desenvolvimento do seu TCC
 description: ''
 date: '2023-09-05 13:00:00'
-tags: []
+tags:
+  - PT_BR
+  - tcc
+  - compression
 ---
 
 # Ferramentas Essenciais para o Desenvolvimento do seu TCC 🛠️📚

--- a/content/pt/posts/tcc.md
+++ b/content/pt/posts/tcc.md
@@ -5,12 +5,8 @@ description: >-
   IoT
 date: '2023-09-05 11:00:00'
 tags:
-  - DIY
   - PT_BR
-  - iot
-  - data
-  - compression
-  - final paper
+  - tcc
 ---
 
 # Desvendando a Eficiência das Técnicas de Compressão de Dados em Dispositivos IoT

--- a/content/pt/posts/teclado-appa.md
+++ b/content/pt/posts/teclado-appa.md
@@ -3,12 +3,10 @@ title: Teclado APPA
 description: Teclado mecânico com teclas ALPS inspirado no plaid
 date: '2023-02-23 16:00:00'
 tags:
-  - DIY
   - PT_BR
-  - Mechanical Keyboards
+  - DIY
   - keyboards
   - qmk
-  - appa
 ---
 
 # Teclado APPA

--- a/content/pt/posts/teclado-momo.md
+++ b/content/pt/posts/teclado-momo.md
@@ -3,12 +3,10 @@ title: Teclado MOMO
 description: Teclado mecânico com hotswap e RGB
 date: '2023-09-23 16:00:00'
 tags:
-  - DIY
   - PT_BR
-  - Mechanical Keyboards
+  - DIY
   - keyboards
   - qmk
-  - momo
 ---
 
 # Minha Jornada de Criação do Teclado Mecânico Momo

--- a/content/pt/posts/terminal-animation.md
+++ b/content/pt/posts/terminal-animation.md
@@ -4,9 +4,9 @@ description: Um Guia Passo a Passo
 date: '2023-09-15 16:00:00'
 tags:
   - PT_BR
-  - CSS
+  - blog
+  - shell
   - animation
-  - HTML5
 ---
 
 # Criando uma Animação CSS Estilo Terminal

--- a/content/pt/posts/tetris-game.md
+++ b/content/pt/posts/tetris-game.md
@@ -3,8 +3,9 @@ title: Desenvolvendo o jogo Tetris em C++ com SDL2 e WebAssembly
 description: ''
 date: '2023-09-10 18:00:00'
 tags:
-  - DIY
   - PT_BR
+  - gaming
+  - c
 ---
 
 # 🎮 Desenvolvendo o jogo Tetris em C++ com SDL2 e WebAssembly 🚀

--- a/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -4,10 +4,8 @@ description: "Como um projeto de scripts shell cresceu e virou uma organização
 date: "2026-07-17 23:00:00"
 tags:
   - PT_BR
-  - DIY
-  - shell
   - suckless
-  - FOSS
+  - shell
 ---
 
 # TinyToolSH: Ferramentas minúsculas para melhorar sua produtividade

--- a/content/pt/posts/zuko-pedal-marshall-diy.md
+++ b/content/pt/posts/zuko-pedal-marshall-diy.md
@@ -7,7 +7,6 @@ tags:
   - DIY
   - guitar
   - open-hardware
-  - ramones
 ---
 
 # Zuko: um pedal Marshall Plexi DIY open hardware


### PR DESCRIPTION
## Summary

Apply new tag taxonomy to all 21 Portuguese posts in `content/pt/posts/`.

## Changes

- **PT_BR** on every post
- **DIY** on applicable posts (keyboards, guitar, ESPBoy)
- Exactly **one series tag** per post (keyboards, guitar, gaming, self-hosting, tcc, suckless, blog)
- **1-3 topic tags** per post (c, sdl2, embedded, esp32, qmk, shell, git, email, compression, animation, open-hardware, ramones, i18n)
- kebab-case, lowercase except acronyms (PT_BR, DIY, C, SDL2, CSS, HTML5, FOSS)
- Removed ad-hoc tags: `Mechanical Keyboards`, `appa`, `momo`, `final paper`, `data`, `iot`, `FOSS` (where redundant)

## Verification

```
npm run build
Found 52 input files
Parsed 52 Markdown files
Emitted 136 files to `public` in 147ms
Done processing 52 files in 1s
```

Build passes, 0 errors.