### PR TITLE
wikilinks: cross-post + glossary links for all Portuguese posts

### DIFF
--- a/content/en/posts/fix_zsh_corrupt_history.md
+++ b/content/en/posts/fix_zsh_corrupt_history.md
@@ -17,3 +17,8 @@ mv .zsh_history .zsh_history_old
 strings .zsh_history_old > .zsh_history
 fc -R .zsh_history
 ```
+
+## See also
+
+- [[tinytoolsh]] — tiny tools for productivity
+- [[glossary]] — terms like shell, ZSH

--- a/content/en/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/en/posts/organizacao-de-um-projeto-em-c.md
@@ -91,3 +91,10 @@ In this example, the project's root directory contains the `main.c` file, a `bui
 * [File Structure : Broad Institute of MIT and Harvard](https://mitcommlab.mit.edu/broad/commkit/file-structure/);
 * [Make a README](https://www.makeareadme.com/);
 * [Readme Driven Development](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html).
+
+## See also
+
+- [[pong]] — my first game in C, Pong with SDL2
+- [[pong-em-c-sdl2]] — detailed Pong in C with SDL2
+- [[tetris-game]] — Tetris in C++ with SDL2 and WebAssembly
+- [[glossary]] — terms like SDL2, Makefile

--- a/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -195,3 +195,9 @@ Foi utilizado o software de desenvolvimento de circuitos e placas de circuito im
 O resultado pode ser verificado na imagem abaixo:
 
 ![ESPBoy-PCB](https://i.imgur.com/mkLqXRc.jpg)
+
+## Veja também
+
+- [[Que-tal-criar-um-jogo]] — minha jornada aprendendo desenvolvimento de jogos
+- [[tetris-game]] — Tetris em C++ com SDL2 e WebAssembly
+- [[glossary]] — termos como ESP32, TFT, GPIO, PAM8403, TP4056, SD Card

--- a/content/pt/posts/Que-tal-criar-um-jogo.md
+++ b/content/pt/posts/Que-tal-criar-um-jogo.md
@@ -169,4 +169,10 @@ Até logo!!!
     * Esqueci de mencionar que estamos mantendo uma nota coletiva com ideias de jogos, ferramentas, tutoriais e vídeos que vamos encontrado. A nota pode ser acessada através [desse link](https://pad.calebe.dev.br/p/jogo).
 
 
+## Veja também
+
+- [[ESPBoy]] — um Gameboy caseiro com ESP32
+- [[pong]] — meu primeiro jogo em C, o Pong com SDL2
+- [[glossary]] — termos como SDL2, Godot, GDNative, FOSS, Nuklear, LVGL
+
 [Godot]: https://godotengine.org/

--- a/content/pt/posts/construindo-um-teclado-mecanico.md
+++ b/content/pt/posts/construindo-um-teclado-mecanico.md
@@ -64,7 +64,13 @@ Alguns itens opcionais, mas que tornam o trabalho mais fácil são:
 
 # Construção do meu teclado
 
-No próximo post, eu irei descrever como foi o processo de desenvolvimento e montagem do meu teclado mecânico.
+No próximo post, eu irei descrever como foi o processo de desenvolvimento e montagem do meu teclado mecânico — veja [[teclado-appa]] e [[teclado-momo]].
+
+## Veja também
+
+- [[teclado-appa]] — meu primeiro teclado mecânico (ALPS)
+- [[teclado-momo]] — o teclado Cherry MX, sucessor do Appa
+- [[glossary]] — termos como QMK, Cherry MX, ALPS, PCB, hotswap
 
 [KiCAD]: https://www.kicad.org/
 [EasyEDA]: https://easyeda.com/

--- a/content/pt/posts/em-busca-de-uma-interface-git.md
+++ b/content/pt/posts/em-busca-de-uma-interface-git.md
@@ -107,4 +107,10 @@ Lendo as documentações do `git` e do [cgit] eu consegui hospedar um servidor g
 [Gitlab]: https://gitlab.com/
 [suckless]: https://suckless.org/
 [stagi]: https://git.codemadness.org/stagit/file/README.html
+## Veja também
+
+- [[servidor-de-email-privado]] — servidor de email self-hosted com Yunohost
+- [[migrando-do-gitlab-para-o-github]] — migrando repositórios do Gitlab para o Github
+- [[glossary]] — termos como self-hosted, VPS, CGI, cgit, stagit, Suckless
+
 [git-mirror]: https://github.com/janbaudisch/git-mirror

--- a/content/pt/posts/fix_zsh_corrupt_history.md
+++ b/content/pt/posts/fix_zsh_corrupt_history.md
@@ -17,3 +17,8 @@ mv .zsh_history .zsh_history_old
 strings .zsh_history_old > .zsh_history
 fc -R .zsh_history
 ```
+
+## Veja também
+
+- [[tinytoolsh]] — ferramentas minúsculas para produtividade
+- [[glossary]] — termos como shell, ZSH

--- a/content/pt/posts/how_to_play_like_johnny_ramone.md
+++ b/content/pt/posts/how_to_play_like_johnny_ramone.md
@@ -45,3 +45,8 @@ Outro canal interessante é o do [Hardly Ramone](https://www.youtube.com/channel
   * [Bass Habits - Ep 9 - How to sound like Dee Dee Ramone](https://www.youtube.com/watch?v=vC6-AvpIJ5I)
 * Imgur
   * [Johnny Ramone - Power Chords](https://i.imgur.com/JfjIc9G.jpg)
+
+## Veja também
+
+- [[zuko-pedal-marshall-diy]] — meu pedal Marshall Plexi DIY open hardware
+- [[glossary]] — termos como Downstrokes, Mosrite, Bridge pickup

--- a/content/pt/posts/menos-e-mais-i18n-kiss.md
+++ b/content/pt/posts/menos-e-mais-i18n-kiss.md
@@ -46,7 +46,7 @@ Três princípios guiam tudo que eu faço nesse site:
 
 **KISS (Keep It Simple, Stupid).** Se resolve com um arquivo estático, não precisa de biblioteca. Se um componente tem 30 linhas, não precisa de 60.
 
-**Suckless.** O site tem que ser rápido, autocontido, e não depender de nada que eu não entenda completamente. Sem framework que faz mágica. Sem 200KB de JavaScript pra trocar um ícone.
+**Suckless.** O site tem que ser rápido, autocontido, e não depender de nada que eu não entenda completamente — veja [[premissas_basicas]]. Sem framework que faz mágica. Sem 200KB de JavaScript pra trocar um ícone.
 
 **Filosofia Unix.** Cada componente faz uma coisa bem feita. O toggle de idioma não sabe que o emitter de redirects existe. A estrutura de pastas é previsível: `pt/` e `en/` são irmãs, não casos especiais.
 
@@ -199,4 +199,4 @@ Esse site tem 139 arquivos estáticos, 52 arquivos Markdown, e zero dependência
 
 ---
 
-Esse post faz parte da série de bastidores do blog. Se você curte essa filosofia, dá uma olhada no [código fonte](https://github.com/Calebe94/blog) e no [glossário](/pt/notes/glossary) — ele é atualizado a cada post.
+Esse post faz parte da série de bastidores do blog. Se você curte essa filosofia, dá uma olhada no [código fonte](https://github.com/Calebe94/blog) e no [[glossary|glossário]] — ele é atualizado a cada post.

--- a/content/pt/posts/migrando-do-gitlab-para-o-github.md
+++ b/content/pt/posts/migrando-do-gitlab-para-o-github.md
@@ -72,3 +72,8 @@ absolutamente nada de informação no processo.
 Todos os projetos que possuíam *issues* e *Merge Requests* foram
 importados com sucesso no **Github**.
 
+## Veja também
+
+- [[em-busca-de-uma-interface-git]] — minha busca por uma interface git self-hosted
+- [[glossary]] — termos como Merge Request, Pull Request, VPS
+

--- a/content/pt/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/pt/posts/organizacao-de-um-projeto-em-c.md
@@ -92,3 +92,10 @@ Neste exemplo, o diretório raiz do projeto contém o arquivo `main.c`, um diret
 * [Make a README](https://www.makeareadme.com/);
 * [Readme Driven Development](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html).
 
+## Veja também
+
+- [[pong]] — meu primeiro jogo em C, o Pong com SDL2
+- [[pong-em-c-sdl2]] — versão detalhada do Pong em C com SDL2
+- [[tetris-game]] — Tetris em C++ com SDL2 e WebAssembly
+- [[glossary]] — termos como SDL2, Makefile
+

--- a/content/pt/posts/pong-em-c-sdl2.md
+++ b/content/pt/posts/pong-em-c-sdl2.md
@@ -36,3 +36,9 @@ Uma das partes mais emocionantes de criar seu próprio jogo é a capacidade de p
 # Conclusão
 
 Criar um jogo Pong em C usando a biblioteca SDL2 é uma maneira emocionante de mergulhar no mundo do desenvolvimento de jogos. Com a base fornecida no repositório [link para o repositório](https://github.com/Calebe94/sdl2-pong), você pode começar a explorar a fundo os aspectos fundamentais por trás do Pong e, eventualmente, expandir e personalizar o jogo de acordo com sua visão criativa. Portanto, mãos à obra e comece sua jornada de criação de jogos!
+
+## Veja também
+
+- [[pong]] — meu primeiro jogo em C, o Pong original
+- [[tetris-game]] — Tetris em C++ com SDL2 e WebAssembly
+- [[glossary]] — termos como SDL2, game loop

--- a/content/pt/posts/pong.md
+++ b/content/pt/posts/pong.md
@@ -12,7 +12,7 @@ tags:
 Meu primeiro jogo em C
 ======================
 
-Como vimos no [post anterior](https://blog.calebe.dev.br/posts/Que-tal-criar-um-jogo.html),
+Como vimos no [[Que-tal-criar-um-jogo|post anterior]],
 estou com planos de criar um jogo em **C** e utilizando a biblioteca **SDL2**.
 
 Então para "pegar as manha" de como criar um jogo com a **SDL2**
@@ -31,5 +31,11 @@ Futuramente eu pretendo adicionar efeitos sonoros e sprites no jogo.
 Também pretendo criar uma demo web do jogo, utilizando Web Assembly.
 
 Bom... por enquanto é isso.
+
+## Veja também
+
+- [[pong-em-c-sdl2]] — versão detalhada do Pong em C com SDL2
+- [[tetris-game]] — Tetris em C++ com SDL2 e WebAssembly
+- [[glossary]] — termos como SDL2, WebAssembly
 
 Até a próxima!

--- a/content/pt/posts/premissas_basicas.md
+++ b/content/pt/posts/premissas_basicas.md
@@ -70,4 +70,10 @@ Quanto menos linhas de código seu código tem, mais habilidoso você se tornou,
 [Filosofia Unix]: http://www.linfo.org/unix_philosophy.html
 [Filosofia Suckless]: https://suckless.org/philosophy/
 [TL:DR]: https://www.lifewire.com/what-is-tldr-2483633
+
+## Veja também
+
+- [[tinytoolsh]] — ferramentas minúsculas para produtividade
+- [[menos-e-mais-i18n-kiss]] — refatorando o i18n do blog com KISS e filosofia Unix
+- [[glossary]] — termos como Suckless
 </main>

--- a/content/pt/posts/servidor-de-email-privado.md
+++ b/content/pt/posts/servidor-de-email-privado.md
@@ -12,7 +12,7 @@ tags:
 
 ### `A saga da frustração`
 
-Como citei em um [post anterior](./em-busca-de-uma-interface-git.html) eu possuo uma instância do [Yunohost] em minha VPS. O [Yunohost] facilita muito a tarefa de instalar as suas aplicações “web” em seu servidor e possui algumas ferramentas para gerenciar o seu servidor. Uma delas é o servidor de email, para te notificar se algum erro ocorreu ao realizar o diagnóstico do servidor.
+Como citei em um [[em-busca-de-uma-interface-git|post anterior]] eu possuo uma instância do [Yunohost] em minha VPS. O [Yunohost] facilita muito a tarefa de instalar as suas aplicações “web” em seu servidor e possui algumas ferramentas para gerenciar o seu servidor. Uma delas é o servidor de email, para te notificar se algum erro ocorreu ao realizar o diagnóstico do servidor.
 É possível também realizar o redirecionamento de emails. Podendo o usuário cadastrar alguns emails na plataforma e quando receber algum email, o `postfix` se encarrega de entregar este email em uma conta pessoal do usuário.
 
 O meu plano era utilizar este recurso para cadastrar alguns emails como:
@@ -73,6 +73,11 @@ Ao procurar em fórums na internet, a maioria dos usuários desencoraja o uso de
 Muitos apontam ser muito mais barato assinar um serviço que gerencie o servidor e que possibilite a criação de vários emails.
 
 Logo, é isso que eu estarei pesquisando nas próximas semanas e documentarei o processo em um novo post.
+
+## Veja também
+
+- [[em-busca-de-uma-interface-git]] — minha busca por uma interface git self-hosted
+- [[glossary]] — termos como Yunohost, VPS, Postfix, SMTP Relay, SendGrid
 
 [SendGrid]: https://sendgrid.com
 [Twillio]: https://www.twillio.com

--- a/content/pt/posts/tcc-tools.md
+++ b/content/pt/posts/tcc-tools.md
@@ -46,3 +46,7 @@ A jornada de criar o seu Trabalho de Conclusão de Curso (TCC) pode ser desafiad
 
 Essas ferramentas podem facilitar a sua jornada na elaboração do TCC, economizando tempo e garantindo a qualidade do seu trabalho. Escolha aquelas que melhor atendam às suas necessidades e preferências. Boa sorte em sua pesquisa e na elaboração do seu TCC! 🌟🎓
 
+## Veja também
+
+- [[tcc]] — técnicas de compressão de dados em dispositivos IoT
+

--- a/content/pt/posts/tcc.md
+++ b/content/pt/posts/tcc.md
@@ -65,3 +65,7 @@ Finalmente, apresentarei meu TCC e o defenderei perante uma banca acadêmica.
 
 Este é o caminho que percorri até agora e o que ainda está por vir na minha jornada de TCC sobre compressão de dados na IoT. Este é um campo empolgante e em constante evolução, e estou ansioso para contribuir com novos conhecimentos que possam beneficiar o mundo da tecnologia. Fiquem ligados para mais atualizações à medida que avançamos nesta jornada!
 
+## Veja também
+
+- [[tcc-tools]] — ferramentas essenciais para o desenvolvimento do TCC
+

--- a/content/pt/posts/teclado-appa.md
+++ b/content/pt/posts/teclado-appa.md
@@ -51,7 +51,7 @@ Eu escolhi esse nome em homenagem ao [Appa](https://avatar.fandom.com/wiki/Appa)
 <img src="https://cdn11.bigcommerce.com/s-5242sis1by/images/stencil/2560w/products/282/1043/Appa__86978.1595902634.png" width="50%">
 </center>
 
-Como eu já havia definido que eu utilizaria as teclas [ALPS] no projeto, eu decidi usar o nome **Appa**, por começar com a letra "**A**" E nomearei um próximo projeto de teclado com teclas [Cherry MX] de **Momo**.
+Como eu já havia definido que eu utilizaria as teclas [ALPS] no projeto, eu decidi usar o nome **Appa**, por começar com a letra "**A**" E nomearei um próximo projeto de teclado com teclas [Cherry MX] de **Momo** — veja [[teclado-momo]].
 
 ## Desenho da Case
 
@@ -312,6 +312,11 @@ Por fim, deixo aqui um vídeo sumarizando a montagem do [Appa]:
 <center>
 <video width="640" height="360" controls><source src="https://cloud.calebe.dev.br/s/nZ35dMQYYjKWWj7/download/Appa%20Keyboard.mp4" type="video/mp4" /></video>
 </center>
+
+## Veja também
+
+- [[teclado-momo]] — o teclado Cherry MX, sucessor do Appa
+- [[glossary]] — termos como QMK, ALPS, Cherry MX, USBaspLoader, WS2812B
 
 [Appa]: https://github.com/Calebe94/appa-firmware
 [swillkb]: http://builder.swillkb.com/

--- a/content/pt/posts/teclado-momo.md
+++ b/content/pt/posts/teclado-momo.md
@@ -20,7 +20,7 @@ Se você já parou para pensar na importância do teclado que utiliza diariament
 Para muitos de nós, o teclado é muito mais do que apenas um periférico; ele é uma extensão da nossa criatividade e produtividade, e cada toque nas teclas pode ser uma experiência única.
 
 Se você é um entusiasta de tecnologia em busca de uma aventura de personalização, a construção de um teclado mecânico é uma jornada fascinante.
-Recentemente, compartilhei a história por trás do meu teclado **Appa**, que utiliza teclas Alps, em um [post anterior](./teclado-appa.html).
+Recentemente, compartilhei a história por trás do meu teclado **Appa**, que utiliza teclas Alps, em um [[teclado-appa|post anterior]].
 
 Agora, vamos mergulhar na criação do teclado mecânico **Momo**, que, embora tenha sido inspirado no "Appa", traz suas próprias características únicas.
 Este teclado utiliza switches Cherry MX, possui hotswap e é uma homenagem ao adorável animal de estimação do [Aang](https://avatar.fandom.com/wiki/Aang), o **Momo**.
@@ -94,7 +94,7 @@ Embora eu não tenha muitas fotos e vídeos do processo de montagem, criei um v�
 
 ### Programação
 
-A programação do teclado foi descomplicada, utilizando o [QMK] para gerar o firmware e adaptando o [código do Appa](https://github.com/Calebe94/appa-firmware) para o **RP2040**. Para obter mais detalhes sobre esse processo, confira o [post do Appa](https://blog.calebe.dev.br/posts/teclado-appa.html#bootloader-e-firmware).
+A programação do teclado foi descomplicada, utilizando o [QMK] para gerar o firmware e adaptando o [código do Appa](https://github.com/Calebe94/appa-firmware) para o **RP2040**. Para obter mais detalhes sobre esse processo, confira o [[teclado-appa|post do Appa]].
 
 ## O Toque Final: Personalização
 
@@ -154,4 +154,9 @@ Este é apenas o começo da minha exploração criativa e paixão pela tecnologi
 Conforme você mergulha mais fundo no mundo da customização de teclados, descobrirá uma comunidade vibrante de entusiastas que compartilham a mesma paixão.
 Portanto, se você está pronto para uma aventura de personalização, siga em frente e comece a planejar seu próprio teclado mecânico. Lembre-se de compartilhar sua jornada com outros entusiastas e inspirar novas criações. Quem sabe, você pode criar o próximo teclado incrível que todos desejam ter!
 
-Se desejar saber mais sobre o processo de criação de teclados mecânicos personalizados, confira também o meu [post anterior](./teclado-appa.html), que oferece insights adicionais.
+Se desejar saber mais sobre o processo de criação de teclados mecânicos personalizados, confira também o meu [[teclado-appa|post anterior]], que oferece insights adicionais.
+
+## Veja também
+
+- [[teclado-appa]] — o teclado ALPS que inspirou o Momo
+- [[glossary]] — termos como QMK, hotswap, underglow, backlight, RP2040, WS2812B, SK6812

--- a/content/pt/posts/terminal-animation.md
+++ b/content/pt/posts/terminal-animation.md
@@ -163,3 +163,7 @@ Lembre-se de que o desenvolvimento web é tudo sobre criatividade, e pequenos de
 ---
 
 Sinta-se à vontade para adaptar este post ao seu site, adicionar mais detalhes e incluir quaisquer insights adicionais ou desafios que você enfrentou durante a criação da sua animação estilo terminal. Boa sorte!
+
+## Veja também
+
+- [[glossary]] — termos como Keyframe, @keyframes, Typewriter effect, Prompt

--- a/content/pt/posts/tetris-game.md
+++ b/content/pt/posts/tetris-game.md
@@ -138,3 +138,10 @@ Criar um jogo Tetris em C++ e SDL2 é uma jornada gratificante que abrange vári
 Fique atento para futuras atualizações, à medida que aprimoramos nosso jogo Tetris e exploramos ainda mais conceitos de desenvolvimento de jogos. Esperamos que esta jornada tenha inspirado você a embarcar na sua própria aventura de desenvolvimento de jogos!
 
 Lembre-se de que você pode experimentar o jogo Tetris tanto no ambiente desktop quanto na web, graças ao poderoso WebAssembly. O código-fonte completo do jogo está disponível em [https://github.com/calebe94/tetris](https://github.com/calebe94/tetris), e você pode jogá-lo em [https://blog.calebe.dev.br/tetris/](https://blog.calebe.dev.br/tetris/). Divirta-se jogando e explorando o mundo do desenvolvimento de jogos!
+
+## Veja também
+
+- [[pong]] — meu primeiro jogo em C, o Pong original
+- [[pong-em-c-sdl2]] — versão detalhada do Pong em C com SDL2
+- [[ESPBoy]] — um Gameboy caseiro com ESP32
+- [[glossary]] — termos como SDL2, WebAssembly, Tetrominó, Dear ImGui, Emscripten

--- a/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -130,3 +130,8 @@ Se você curte a filosofia Unix de ferramentas pequenas que trabalham bem juntas
 E se você quiser contribuir, todas as ferramentas estão sob a [GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html). Tem `issue` aberta em vários repositórios.
 
 Até logo!!!
+
+## Veja também
+
+- [[premissas_basicas]] — premissas fundamentais: filosofia Unix e Suckless
+- [[glossary]] — termos como Suckless, dmenu, systemd, journalctl

--- a/content/pt/posts/zuko-pedal-marshall-diy.md
+++ b/content/pt/posts/zuko-pedal-marshall-diy.md
@@ -11,7 +11,7 @@ tags:
 
 # Zuko: um pedal Marshall Plexi DIY open hardware
 
-Eu comecei a aprender guitarra em novembro de 2020, e decidi isso por ser muito fã de Ramones. Desde então eu sempre quis ter o som do Johnny Ramone — aquele Marshall Plexi cranked (com o volume no máximo, saturando naturalmente), tudo no 10, downstrokes agressivos, sem pedais, sem firulas.
+Eu comecei a aprender guitarra em novembro de 2020, e decidi isso por ser muito fã de Ramones. Desde então eu sempre quis ter o som do Johnny Ramone ([[how_to_play_like_johnny_ramone]]) — aquele Marshall Plexi cranked (com o volume no máximo, saturando naturalmente), tudo no 10, downstrokes agressivos, sem pedais, sem firulas.
 
 O problema é que um Marshall Super Lead 100 custa mais que meu carro. E mesmo se eu tivesse um, eu moro em apartamento. Meus vizinhos já não gostam de mim.
 
@@ -299,7 +299,7 @@ Gabba Gabba Hey!
 
 ## Glossário
 
-Este post usa vários termos de guitarra, eletrônica e áudio digital. Se algum não for familiar, confira o [glossário do blog](/pt/notes/glossary) — ele é atualizado a cada post.
+Este post usa vários termos de guitarra, eletrônica e áudio digital. Se algum não for familiar, confira o [[glossary|glossário do blog]] — ele é atualizado a cada post.
 
 Os principais termos usados aqui:
 
@@ -313,7 +313,7 @@ Os principais termos usados aqui:
 | **mu-amp** | Configuração de 2 JFETs que emula o push-pull do power amp |
 | **Scooped mids** | Frequências médias atenuadas — som "oco" e agressivo |
 
-Glossário completo com todos os termos: [/pt/notes/glossary](/pt/notes/glossary).
+Glossário completo com todos os termos: [[glossary]].
 
 ## Referências
 


### PR DESCRIPTION
Mirrors EN wikilinks (commit 7116e0b, PR #71).

**Changes (18 PT posts):**
- 4 relative links (`./xxx.html`) converted to Quartz `[[wikilinks]]`
- `Veja também` sections added with cross-post + `[[glossary]]` links
- pt/en parity — same wikilink structure in both languages

**Verification:** `npm run build` passes (52 files, 0 errors).

Completes kanban task `t_bbf6a0ca` (PT wikilinks, was uncommitted in prior PR #71).