### PR TITLE
fix(content): remove redundant H1 headers matching frontmatter titles

### DIFF
--- a/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/en/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -10,8 +10,6 @@ tags:
   - esp32
 ---
 
-# Specification:
-
 Develop a portable console using the ESP32 microcontroller to be presented at the [Mostra de Profissões](https://www.up.edu.br/blogs/mostra-de-profissoes/) (Career Fair) at Universidade Positivo on August 1st, 2018.
 
 The console should be able to emulate games from the 4th generation of portable consoles like the [Gameboy](https://en.wikipedia.org/wiki/Game_Boy) and [Game Gear](https://en.wikipedia.org/wiki/Game_Gear), as well as 3rd generation consoles like the [Master System](https://en.wikipedia.org/wiki/Master_System) and [NES](https://en.wikipedia.org/wiki/Nintendo_Entertainment_System). The console must be capable of running at least one game from any of the above consoles during the presentation — meaning there's no need to implement all emulators or the ability to load multiple games on the same device.

--- a/content/en/posts/Que-tal-criar-um-jogo.md
+++ b/content/en/posts/Que-tal-criar-um-jogo.md
@@ -7,8 +7,6 @@ tags:
   - gaming
 ---
 
-# How about making a game?
-
 Recently a friend of mine started taking a
 [Unity](https://unity.com/) course, and during a chat we got really
 excited about making a game.

--- a/content/en/posts/em-busca-de-uma-interface-git.md
+++ b/content/en/posts/em-busca-de-uma-interface-git.md
@@ -8,8 +8,6 @@ tags:
   - git
 ---
 
-# In Search of a Self-Hosted Git Interface
-
 I was on the hunt for a `git` interface to host my projects on my own server, serving as a sort of portfolio.
 
 I already knew that [gitlab] allows users to create their own instance (self-host) on their servers, and I had hosted a [gitlab] instance on my VPS myself.

--- a/content/en/posts/m5-pro-48gb-hermes-local-llm-pipeline.md
+++ b/content/en/posts/m5-pro-48gb-hermes-local-llm-pipeline.md
@@ -11,8 +11,6 @@ tags:
   - opensource
 ---
 
-# How I Retired R$200/month in Cloud LLMs with an M5 Pro 48GB and a Hybrid Pipeline using Claude, Gemini, and Ollama
-
 If you use autonomous terminal agents like [Hermes Agent](https://hermes-agent.nousresearch.com/docs) for daily automation, you know that the biggest bottleneck isn't AI capability — it's your bank balance.
 
 Recently, I found myself stuck in a frustrating cycle: a $20/month subscription on [Ollama Cloud](https://ollama.com/cloud) that ran out of credits mid-week. My Kanban automations, journal summarizers, and background cron jobs would suddenly crash with the dreaded `HTTP 402: Payment Required` error. Tasks were left marked as `(no response)` on the board, and my agent was left completely blind.

--- a/content/en/posts/menos-e-mais-i18n-kiss.md
+++ b/content/en/posts/menos-e-mais-i18n-kiss.md
@@ -9,8 +9,6 @@ tags:
   - i18n
 ---
 
-# Less is more: refactoring the blog's i18n with KISS and Unix philosophy
-
 If you've ever tried to maintain a site in two languages, you know the annoying part isn't translating the content — it's the infrastructure. Where do the files go? How do you build the toggle? What do you do with old links when you move everything around?
 
 I'd been kicking these problems down the road ever since I migrated the blog from Astro Cactus to Quartz 4. It worked, but it was ugly. And I'm the kind of person who gets bothered by ugly things.

--- a/content/en/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/en/posts/organizacao-de-um-projeto-em-c.md
@@ -7,8 +7,6 @@ tags:
   - c
 ---
 
-# Organizing a C project
-
 I love keeping my source files organized in a logical, consistent file structure — it's absolutely essential for the maintainability, readability, and scalability of my code!
 
 Here are some of the best practices I follow when organizing source files into a file structure hierarchy:

--- a/content/en/posts/pong-em-c-sdl2.md
+++ b/content/en/posts/pong-em-c-sdl2.md
@@ -9,8 +9,6 @@ tags:
   - sdl2
 ---
 
-# Building the Classic Pong in C with SDL2
-
 I've always been fascinated by the classics — and Pong is THE classic. The game that started it all, defined the sports genre, and still holds up as a perfect starting point for anyone wanting to dip their toes into game development. So I decided to build it myself in C using SDL2 — and you can too!
 
 <center>

--- a/content/en/posts/servidor-de-email-privado.md
+++ b/content/en/posts/servidor-de-email-privado.md
@@ -8,8 +8,6 @@ tags:
   - email
 ---
 
-# Self-hosted email server
-
 ### `The saga of frustration`
 
 As I mentioned in a [[em-busca-de-uma-interface-git|previous post]], I have a [Yunohost] instance running on my VPS. [Yunohost] makes it incredibly easy to install your "web" apps on your server and comes with some handy tools to manage everything. One of those tools is the email server, which notifies you if any errors occur during server diagnostics.

--- a/content/en/posts/tcc-tools.md
+++ b/content/en/posts/tcc-tools.md
@@ -8,8 +8,6 @@ tags:
   - compression
 ---
 
-# Essential Tools for Developing Your Final Year Project 🛠️📚
-
 The journey of creating your Final Year Project (TCC — Trabalho de Conclusão de Curso) can be challenging, but with the right tools, you can make this process smoother and more productive. Here is a list of essential tools that cover everything from research to final formatting, with a touch of emojis to liven up your academic journey! 🚀🎓
 
 **1. [Zotero](https://www.zotero.org/) or [Mendeley](https://www.mendeley.com/) (Reference Management) 📑🧐:** These tools help you organize and manage your bibliographic references, making it easier to cite sources and build your reference list according to ABNT standards.

--- a/content/en/posts/tcc.md
+++ b/content/en/posts/tcc.md
@@ -8,8 +8,6 @@ tags:
   - tcc
 ---
 
-# Unveiling the Efficiency of Data Compression Techniques in IoT Devices
-
 The academic journey toward completing a Final Year Project (TCC) is a challenging and rewarding experience. Along this path, it is essential to choose a theme that not only sparks your interest but also holds relevance in the current context. In my case, the choice fell upon a theme at the epicenter of the technological revolution: the "Efficiency of Data Compression Techniques in Resource-Constrained IoT Devices."
 
 The Internet of Things (IoT) is a reality unfolding before us, connecting devices, sensors, and systems in a global network. It has the potential to transform our lives and our cities, making them smarter and more efficient. However, this explosion of IoT devices brings significant challenges, especially when it comes to data management.

--- a/content/en/posts/teclado-appa.md
+++ b/content/en/posts/teclado-appa.md
@@ -9,8 +9,6 @@ tags:
   - qmk
 ---
 
-# APPA Keyboard
-
 In my second-to-last blog post I covered [how to build your own mechanical keyboard](https://blog.calebe.dev.br/posts/construindo-um-teclado-mecanico.html).
 
 In this post I'll describe the process of building my mechanical keyboard, which I called [Appa].

--- a/content/en/posts/teclado-momo.md
+++ b/content/en/posts/teclado-momo.md
@@ -9,8 +9,6 @@ tags:
   - qmk
 ---
 
-# My Journey Building the Momo Mechanical Keyboard
-
 <center>
 <img src="https://cloud.calebe.dev.br/apps/files_sharing/publicpreview/bSA9yGCm7WqrWX2?file=/&fileId=122528&x=3840&y=2160&a=true" width="70%">
 </center>

--- a/content/en/posts/terminal-animation.md
+++ b/content/en/posts/terminal-animation.md
@@ -9,8 +9,6 @@ tags:
   - animation
 ---
 
-# Creating a Terminal-Style CSS Animation
-
 Sometimes it's the little details that make a site stand out. I wanted to add a terminal-style CSS animation to my site — complete with a typing effect and a blinking cursor. It's an eye-catching touch that gives the page personality. Let me show you how I did it!
 
 ## Planning the Animation

--- a/content/en/posts/tetris-game.md
+++ b/content/en/posts/tetris-game.md
@@ -8,8 +8,6 @@ tags:
   - c
 ---
 
-# 🎮 Building Tetris in C++ with SDL2 and WebAssembly 🚀
-
 In the world of game development, Tetris is a classic that needs no introduction. Its simple yet addictive gameplay has captivated players for decades. In this post, I'll take you on a journey through the process of creating a Tetris game in C++ using the SDL2 library and explore how to bring this game to the web using WebAssembly. We'll cover the key steps and concepts, from setting up the development environment to implementing the game mechanics and user interfaces.
 
 <center>

--- a/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/en/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -8,8 +8,6 @@ tags:
   - shell
 ---
 
-# TinyToolSH: Tiny tools to boost your productivity
-
 [Gabo](https://github.com/gbgabo) and I share a very similar philosophy when it comes to software: small things that do one thing really well. It's no coincidence we're fans of the [suckless philosophy](https://suckless.org/philosophy/).
 
 Sometime in 2020 we started writing small `shell` scripts to automate boring day-to-day tasks. Simple things: a `dmenu` wrapper for creating Markdown notes, a terminal pomodoro timer, a script that downloads satellite images from [GOES](https://www.star.nesdis.noaa.gov/GOES/) and sets them as wallpaper.

--- a/content/en/posts/zuko-pedal-marshall-diy.md
+++ b/content/en/posts/zuko-pedal-marshall-diy.md
@@ -9,8 +9,6 @@ tags:
   - open-hardware
 ---
 
-# Zuko: a DIY open hardware Marshall Plexi pedal
-
 I started learning guitar in November 2020, and I decided to do it because I'm a huge Ramones fan. Ever since then I've always wanted Johnny Ramone's tone — that cranked Marshall Plexi (volume maxed out, saturating naturally), everything on 10, aggressive downstrokes, no pedals, no nonsense.
 
 The problem is that a Marshall Super Lead 100 costs more than my car. And even if I had one, I live in an apartment. My neighbors already don't like me.

--- a/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
+++ b/content/pt/posts/ESPBoy-A-ESP32-Gameboy.md
@@ -10,8 +10,6 @@ tags:
   - esp32
 ---
 
-# Especificação:
-
 Desenvolver um console portátil utilizando o microcontrolador ESP32 para ser apresentado na [Mostra de Profissões](https://www.up.edu.br/blogs/mostra-de-profissoes/) da Universidade Positivo no dia 1.º de agosto de 2018.
 
 O console deverá conseguir emular jogos da (4.º) geração de consoles portáteis como o [Gameboy](https://pt.wikipedia.org/wiki/Game_Boy) e  [Game Gear](https://pt.wikipedia.org/wiki/Game_Gear) e também consoles da (3.º) geração como  [Master System](https://pt.wikipedia.org/wiki/Master_System) e [NES](https://pt.wikipedia.org/wiki/NES). Sendo que,  console seja capaz de rodar pelo menos 1(um) jogo de qualquer um dos consoles acima durante a apresentação, ou seja, não há a necessidade de implementar todos os emuladores e nem a capacidade de inserir diversos jogos no mesmo dispositivo.

--- a/content/pt/posts/Que-tal-criar-um-jogo.md
+++ b/content/pt/posts/Que-tal-criar-um-jogo.md
@@ -7,8 +7,6 @@ tags:
   - gaming
 ---
 
-# Que tal criar um jogo?
-
 Recentemente um amigo meu começou a fazer um curso de
 [Unity](https://unity.com/) e durante uma conversa nós ficamos muito
 empolgados em criar um jogo.

--- a/content/pt/posts/construindo-um-teclado-mecanico.md
+++ b/content/pt/posts/construindo-um-teclado-mecanico.md
@@ -9,8 +9,6 @@ tags:
   - qmk
 ---
 
-# Construindo seu próprio teclado mecânico do zero
-
 Se você deseja criar seu próprio teclado, há algumas coisas que você precisa fazer.
 Primeiro, você precisa decidir que categoria de teclado deseja criar.
 

--- a/content/pt/posts/em-busca-de-uma-interface-git.md
+++ b/content/pt/posts/em-busca-de-uma-interface-git.md
@@ -8,8 +8,6 @@ tags:
   - git
 ---
 
-# Em busca de uma interface git self-hosted
-
 Estive em busca de uma interface `git` para hospedar os meus projetos em meu próprio servidor, para de certa forma servir de meu portifólio.
 
 Eu já tinha conhecimento de que o [gitlab] permite que os usuários criem a sua própria instância(self-host) em seus servidores, e eu mesmo já hospedei uma instância do [gitlab] em minha VPS.

--- a/content/pt/posts/m5-pro-48gb-hermes-local-llm-pipeline.md
+++ b/content/pt/posts/m5-pro-48gb-hermes-local-llm-pipeline.md
@@ -11,8 +11,6 @@ tags:
   - opensource
 ---
 
-# Como aposentei R$200/mês de LLM Cloud com um M5 Pro 48GB e um pipeline híbrido com Claude, Gemini e Ollama
-
 Se você usa agentes autônomos no terminal como o [Hermes Agent](https://hermes-agent.nousresearch.com/docs) para automação diária, sabe que o maior gargalo não é a capacidade da IA — é o saldo da sua conta.
 
 Recentemente eu me vi preso num ciclo frustrante: uma assinatura de $20/mês no [Ollama Cloud](https://ollama.com/cloud) que estourava o limite de créditos no meio da semana. Minhas automações de Kanban, summarizers de journal e cron jobs de background paravam de funcionar do nada com o famigerado erro `HTTP 402: Payment Required`. Tasks ficavam marcadas como `(no response)` no board, e o meu agente ficava cego.

--- a/content/pt/posts/menos-e-mais-i18n-kiss.md
+++ b/content/pt/posts/menos-e-mais-i18n-kiss.md
@@ -9,8 +9,6 @@ tags:
   - i18n
 ---
 
-# Menos é mais: refatorando o i18n do blog com KISS e filosofia Unix
-
 Se você já tentou manter um site em dois idiomas, sabe que a parte mais chata não é traduzir o conteúdo — é a infraestrutura. Onde colocar os arquivos? Como fazer o toggle? O que fazer com os links antigos quando você muda tudo de lugar?
 
 Eu vinha empurrando esses problemas com a barriga desde que migrei o blog do Astro Cactus pro Quartz 4. Funcionava, mas era feio. E eu sou o tipo de pessoa que se incomoda com coisa feia.

--- a/content/pt/posts/organizacao-de-um-projeto-em-c.md
+++ b/content/pt/posts/organizacao-de-um-projeto-em-c.md
@@ -7,8 +7,6 @@ tags:
   - c
 ---
 
-# Organização de projeto em C
-
 Organizar seus arquivos de código fonte em uma estrutura de arquivos lógica e consistente é importante para a manutenibilidade, legibilidade e escalabilidade do código.
 
 Aqui estão algumas das melhores práticas para organizar arquivos de origem em pastas de estrutura de arquivos:

--- a/content/pt/posts/pong-em-c-sdl2.md
+++ b/content/pt/posts/pong-em-c-sdl2.md
@@ -9,8 +9,6 @@ tags:
   - sdl2
 ---
 
-# Desenvolvendo o Clássico Pong em C com a Biblioteca SDL2
-
 O mundo dos jogos eletrônicos é repleto de clássicos que marcaram gerações. Um desses jogos é o lendário Pong, que definiu o gênero de jogos de esporte virtual. Se você é um entusiasta da programação e deseja mergulhar na criação de jogos, está no lugar certo! Nesta postagem, vamos explorar como desenvolver o icônico jogo Pong em C, utilizando a poderosa biblioteca SDL2.
 
 <center>

--- a/content/pt/posts/servidor-de-email-privado.md
+++ b/content/pt/posts/servidor-de-email-privado.md
@@ -8,8 +8,6 @@ tags:
   - email
 ---
 
-# Servidor de email (self-hosted)
-
 ### `A saga da frustração`
 
 Como citei em um [[em-busca-de-uma-interface-git|post anterior]] eu possuo uma instância do [Yunohost] em minha VPS. O [Yunohost] facilita muito a tarefa de instalar as suas aplicações “web” em seu servidor e possui algumas ferramentas para gerenciar o seu servidor. Uma delas é o servidor de email, para te notificar se algum erro ocorreu ao realizar o diagnóstico do servidor.

--- a/content/pt/posts/tcc-tools.md
+++ b/content/pt/posts/tcc-tools.md
@@ -8,8 +8,6 @@ tags:
   - compression
 ---
 
-# Ferramentas Essenciais para o Desenvolvimento do seu TCC 🛠️📚
-
 A jornada de criar o seu Trabalho de Conclusão de Curso (TCC) pode ser desafiadora, mas com as ferramentas certas, você pode tornar esse processo mais suave e produtivo. Aqui está uma lista de ferramentas essenciais que vão desde a pesquisa até a formatação final, com um toque de emojis para animar sua jornada acadêmica! 🚀🎓
 
 **1. [Zotero](https://www.zotero.org/) ou [Mendeley](https://www.mendeley.com/) (Gerenciamento de Referências) 📑🧐:** Essas ferramentas ajudam a organizar e gerenciar suas referências bibliográficas, facilitando a citação e a criação da lista de referências de acordo com as normas da ABNT.

--- a/content/pt/posts/tcc.md
+++ b/content/pt/posts/tcc.md
@@ -9,8 +9,6 @@ tags:
   - tcc
 ---
 
-# Desvendando a Eficiência das Técnicas de Compressão de Dados em Dispositivos IoT
-
 A jornada acadêmica rumo à conclusão do Trabalho de Conclusão de Curso (TCC) é uma experiência desafiadora e recompensadora. Ao longo desse percurso, é fundamental escolher um tema que não apenas desperte seu interesse, mas também tenha relevância no contexto atual. No meu caso, a escolha recaiu sobre um tema que está no epicentro da revolução tecnológica: a "Eficiência das Técnicas de Compressão de Dados em Dispositivos IoT com Recursos Limitados".
 
 A Internet das Coisas (IoT) é uma realidade que se desdobra diante de nós, conectando dispositivos, sensores e sistemas em uma rede global. Ela tem o potencial de transformar nossas vidas e nossas cidades, tornando-as mais inteligentes e eficientes. No entanto, essa explosão de dispositivos IoT traz consigo desafios significativos, especialmente quando se trata de gerenciamento de dados.

--- a/content/pt/posts/teclado-appa.md
+++ b/content/pt/posts/teclado-appa.md
@@ -9,8 +9,6 @@ tags:
   - qmk
 ---
 
-# Teclado APPA
-
 No penúltimo post do blog eu abordei o assunto de [Como construir seu próprio teclado mecânico](https://blog.calebe.dev.br/posts/construindo-um-teclado-mecanico.html).
 
 Neste post eu irei descrever os processos de construção do meu teclado mecânico, que eu chamei de [Appa].

--- a/content/pt/posts/teclado-momo.md
+++ b/content/pt/posts/teclado-momo.md
@@ -9,8 +9,6 @@ tags:
   - qmk
 ---
 
-# Minha Jornada de Criação do Teclado Mecânico Momo
-
 <center>
 <img src="https://cloud.calebe.dev.br/apps/files_sharing/publicpreview/bSA9yGCm7WqrWX2?file=/&fileId=122528&x=3840&y=2160&a=true" width="70%">
 </center>

--- a/content/pt/posts/terminal-animation.md
+++ b/content/pt/posts/terminal-animation.md
@@ -9,8 +9,6 @@ tags:
   - animation
 ---
 
-# Criando uma Animação CSS Estilo Terminal
-
 No mundo do desenvolvimento web, a criatividade não tem limites. Às vezes, são os pequenos detalhes que fazem um site se destacar. Neste post, vamos levá-lo a uma jornada pelo processo de criação de uma animação CSS estilo terminal, completa com um efeito de digitação e um cursor piscante. Essa animação chamativa pode ser uma adição única ao seu site. Vamos lá!
 
 ## Planejando a Animação

--- a/content/pt/posts/tetris-game.md
+++ b/content/pt/posts/tetris-game.md
@@ -8,8 +8,6 @@ tags:
   - c
 ---
 
-# 🎮 Desenvolvendo o jogo Tetris em C++ com SDL2 e WebAssembly 🚀
-
 No mundo do desenvolvimento de jogos, Tetris é um clássico que dispensa apresentações. Sua jogabilidade simples, porém viciante, cativou jogadores por décadas. Neste post, levaremos você a uma jornada pelo processo de criação de um jogo Tetris em C++ usando a biblioteca SDL2 e exploraremos como levar esse jogo para a web usando WebAssembly. Vamos abordar os passos e conceitos-chave, desde a configuração do ambiente de desenvolvimento até a implementação da mecânica do jogo e das interfaces de usuário.
 
 <center>

--- a/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
+++ b/content/pt/posts/tinytoolsh-ferramentas-minuculas-para-produtividade.md
@@ -8,8 +8,6 @@ tags:
   - shell
 ---
 
-# TinyToolSH: Ferramentas minúsculas para melhorar sua produtividade
-
 Eu e o [Gabo](https://github.com/gbgabo) compartilhamos de uma filosofia bem parecida quando se trata de software: coisas pequenas que fazem uma coisa bem feita. Não é à toa que somos fãs da [filosofia suckless](https://suckless.org/philosophy/).
 
 Em algum momento de 2020 nós começamos a escrever pequenos scripts em `shell` para automatizar tarefas chatas do dia a dia. Coisas simples: um wrapper do `dmenu` para criar notas em Markdown, um cronômetro pomodoro no terminal, um script que baixa imagens de satélite do [GOES](https://www.star.nesdis.noaa.gov/GOES/) e coloca como wallpaper.

--- a/content/pt/posts/zuko-pedal-marshall-diy.md
+++ b/content/pt/posts/zuko-pedal-marshall-diy.md
@@ -9,8 +9,6 @@ tags:
   - open-hardware
 ---
 
-# Zuko: um pedal Marshall Plexi DIY open hardware
-
 Eu comecei a aprender guitarra em novembro de 2020, e decidi isso por ser muito fã de Ramones. Desde então eu sempre quis ter o som do Johnny Ramone ([[how_to_play_like_johnny_ramone]]) — aquele Marshall Plexi cranked (com o volume no máximo, saturando naturalmente), tudo no 10, downstrokes agressivos, sem pedais, sem firulas.
 
 O problema é que um Marshall Super Lead 100 custa mais que meu carro. E mesmo se eu tivesse um, eu moro em apartamento. Meus vizinhos já não gostam de mim.


### PR DESCRIPTION
## Summary
- Removes duplicate  H1 headings from post Markdown files in both  and .
- Quartz 4 automatically injects the frontmatter title as the H1 ( component) and sets the page title in the browser navigation.
- Having  right under frontmatter caused 3 redundant title repetitions (Browser Title/Nav, ArticleTitle, and MD H1 Body).
- Updated  skill to forbid manual  headers in future post drafts.