### PR TITLE
fix(ui): persist reader-mode across language switches and improve explorer scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "node quartz/bootstrap-cli.mjs build",
     "serve": "node quartz/bootstrap-cli.mjs build --serve",
     "check": "tsc --noEmit && npx prettier . --check",
-    "format": "npx prettier . --write"
+    "format": "npx prettier . --write",
+    "test": "node --import tsx --test quartz/components/scripts/readermode.inline.test.ts"
   },
   "engines": {
     "npm": ">=10.9.2",

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -228,7 +228,7 @@ async function setupExplorer(currentSlug: FullSlug) {
       // try to scroll to the active element if it exists
       const activeElement = explorerUl.querySelector(".active")
       if (activeElement) {
-        activeElement.scrollIntoView({ behavior: "smooth" })
+        activeElement.scrollIntoView({ behavior: "smooth", block: "nearest" })
       }
     }
 

--- a/quartz/components/scripts/readermode.inline.test.ts
+++ b/quartz/components/scripts/readermode.inline.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { runInNewContext } from "node:vm";
+import esbuild from "esbuild";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const readerModeSrc = fs.readFileSync(
+  path.join(__dirname, "readermode.inline.ts"),
+  "utf8",
+);
+const langToggleSrc = fs.readFileSync(
+  path.join(__dirname, "langtoggle.inline.ts"),
+  "utf8",
+);
+
+function compileInlineScript(name: string, src: string): string {
+  const result = esbuild.transformSync(src, {
+    format: "iife",
+    loader: "ts",
+    platform: "browser",
+    target: "esnext",
+  });
+  if (result.warnings.length > 0) {
+    console.warn(`esbuild warnings for ${name}:`, result.warnings);
+  }
+  return result.code;
+}
+
+const readerModeScript = compileInlineScript("readermode", readerModeSrc);
+const langToggleScript = compileInlineScript("langtoggle", langToggleSrc);
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function createStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+class MockElement {
+  private attributes = new Map<string, string>();
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(readonly className: string) {}
+
+  addEventListener(type: string, handler: (...args: unknown[]) => void) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)!.add(handler);
+  }
+
+  removeEventListener(type: string, handler: (...args: unknown[]) => void) {
+    this.listeners.get(type)?.delete(handler);
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  dispatchEvent(event: { type: string }) {
+    for (const handler of this.listeners.get(event.type) ?? []) {
+      handler(event);
+    }
+  }
+
+  click() {
+    this.dispatchEvent({ type: "click" });
+  }
+}
+
+interface MockDocument {
+  documentElement: MockElement;
+  addEventListener(type: string, handler: (...args: unknown[]) => void): void;
+  removeEventListener(
+    type: string,
+    handler: (...args: unknown[]) => void,
+  ): void;
+  dispatchEvent(event: { type: string }): void;
+  getElementsByClassName(className: string): MockElement[];
+}
+
+function createMockDocument(elements: MockElement[]): MockDocument {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const documentElement = new MockElement("");
+
+  return {
+    documentElement,
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) {
+        listeners.set(type, new Set());
+      }
+      listeners.get(type)!.add(handler);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    dispatchEvent(event) {
+      for (const handler of listeners.get(event.type) ?? []) {
+        handler(event);
+      }
+    },
+    getElementsByClassName(className) {
+      return elements.filter((el) => el.className === className);
+    },
+  };
+}
+
+interface Page {
+  document: MockDocument;
+  readerButton: MockElement;
+  langButton: MockElement;
+  assignedURL: string | null;
+  runScripts(): void;
+  dispatchNav(): void;
+}
+
+function createPage(pathname: string, storage: StorageLike): Page {
+  const readerButton = new MockElement("readermode");
+  const langButton = new MockElement("langtoggle");
+  const document = createMockDocument([readerButton, langButton]);
+
+  let assignedURL: string | null = null;
+  const cleanup: (() => void)[] = [];
+
+  const window = {
+    location: {
+      pathname,
+      assign(url: string) {
+        assignedURL = url;
+      },
+    },
+    addCleanup(fn: () => void) {
+      cleanup.push(fn);
+    },
+  };
+
+  const CustomEvent = class {
+    readonly detail?: unknown;
+    constructor(
+      readonly type: string,
+      init?: { detail?: unknown },
+    ) {
+      this.detail = init?.detail;
+    }
+  };
+
+  const context = {
+    console,
+    document,
+    localStorage: storage,
+    window,
+    CustomEvent,
+  };
+
+  return {
+    document,
+    readerButton,
+    langButton,
+    get assignedURL() {
+      return assignedURL;
+    },
+    runScripts() {
+      runInNewContext(readerModeScript, context, {
+        filename: "readermode.inline.ts",
+      });
+      runInNewContext(langToggleScript, context, {
+        filename: "langtoggle.inline.ts",
+      });
+    },
+    dispatchNav() {
+      document.dispatchEvent(
+        new CustomEvent("nav", { detail: { url: pathname } }),
+      );
+    },
+  };
+}
+
+test("reader mode persists across language toggle in both directions", () => {
+  const storage = createStorage();
+
+  // Load an English page and activate reader mode
+  let page = createPage("/en/posts/foo", storage);
+  page.runScripts();
+  page.dispatchNav();
+  assert.equal(
+    page.document.documentElement.getAttribute("reader-mode"),
+    "off",
+  );
+
+  page.readerButton.click();
+  assert.equal(page.document.documentElement.getAttribute("reader-mode"), "on");
+  assert.equal(storage.getItem("reader-mode"), "on");
+
+  // Toggle language: English -> Portuguese
+  page.langButton.click();
+  assert.equal(page.assignedURL, "/pt/posts/foo");
+  assert.equal(storage.getItem("lang"), "pt");
+
+  // Simulate full page reload at the new URL with the same localStorage
+  page = createPage("/pt/posts/foo", storage);
+  page.runScripts();
+  page.dispatchNav();
+  assert.equal(page.document.documentElement.getAttribute("reader-mode"), "on");
+  assert.equal(storage.getItem("reader-mode"), "on");
+
+  // Toggle language back: Portuguese -> English
+  page.langButton.click();
+  assert.equal(page.assignedURL, "/en/posts/foo");
+  assert.equal(storage.getItem("lang"), "en");
+
+  page = createPage("/en/posts/foo", storage);
+  page.runScripts();
+  page.dispatchNav();
+  assert.equal(page.document.documentElement.getAttribute("reader-mode"), "on");
+});
+
+test("reader mode defaults to off when nothing is stored", () => {
+  const storage = createStorage();
+  const page = createPage("/en/posts/foo", storage);
+  page.runScripts();
+  page.dispatchNav();
+  assert.equal(
+    page.document.documentElement.getAttribute("reader-mode"),
+    "off",
+  );
+  assert.equal(storage.getItem("reader-mode"), "off");
+});

--- a/quartz/components/scripts/readermode.inline.ts
+++ b/quartz/components/scripts/readermode.inline.ts
@@ -1,4 +1,17 @@
-let isReaderMode = false
+const STORAGE_KEY = "reader-mode"
+
+const getSavedReaderMode = (): "on" | "off" => {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  return saved === "on" ? "on" : "off"
+}
+
+let isReaderMode = getSavedReaderMode() === "on"
+
+const setReaderMode = (mode: "on" | "off") => {
+  isReaderMode = mode === "on"
+  document.documentElement.setAttribute("reader-mode", mode)
+  localStorage.setItem(STORAGE_KEY, mode)
+}
 
 const emitReaderModeChangeEvent = (mode: "on" | "off") => {
   const event: CustomEventMap["readermodechange"] = new CustomEvent("readermodechange", {
@@ -9,9 +22,8 @@ const emitReaderModeChangeEvent = (mode: "on" | "off") => {
 
 document.addEventListener("nav", () => {
   const switchReaderMode = () => {
-    isReaderMode = !isReaderMode
-    const newMode = isReaderMode ? "on" : "off"
-    document.documentElement.setAttribute("reader-mode", newMode)
+    const newMode = isReaderMode ? "off" : "on"
+    setReaderMode(newMode)
     emitReaderModeChangeEvent(newMode)
   }
 
@@ -20,6 +32,7 @@ document.addEventListener("nav", () => {
     window.addCleanup(() => readerModeButton.removeEventListener("click", switchReaderMode))
   }
 
-  // Set initial state
-  document.documentElement.setAttribute("reader-mode", isReaderMode ? "on" : "off")
+  // Restore saved state on every navigation (SPA and full page loads)
+  const savedMode = getSavedReaderMode()
+  setReaderMode(savedMode)
 })


### PR DESCRIPTION
## Summary

Fixes reader-mode not surviving language switches and active explorer items jumping the page on load.

## Changes

- **readermode.inline.ts**: persist reader-mode preference in ; restore on every navigation event (SPA and full page loads).
- **explorer.inline.ts**: change active-element  to  to avoid scrolling the whole page.
- **package.json**: add 
> blog-calebe94@4.0.0 test
> node --import tsx --test quartz/components/scripts/readermode.inline.test.ts

(node:42907) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ reader mode persists across language toggle in both directions (3.19125ms)
✔ reader mode defaults to off when nothing is stored (0.582833ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 504.100209 script to run the new regression test.
- **readermode.inline.test.ts**: regression test that simulates activation, language toggle, and fresh load.

## Verification

- 
> blog-calebe94@4.0.0 build
> node quartz/bootstrap-cli.mjs build


 Quartz v4.0.0  

Cleaned output directory `public` in 10ms
Found 54 input files from `content` in 9ms
Parsing input files using 1 threads
Parsed 54 Markdown files in 764ms
Filtered out 0 files in 57μs
Emitting files
Emitted 143 files to `public` in 138ms
Done processing 54 files in 921ms passes
- 
> blog-calebe94@4.0.0 test
> node --import tsx --test quartz/components/scripts/readermode.inline.test.ts

(node:42968) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ reader mode persists across language toggle in both directions (1.444667ms)
✔ reader mode defaults to off when nothing is stored (0.2055ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 119.404917 passes (2/2)

Parent task: quartz reader-mode language-switch fix.
