### PR TITLE
feat(content): add subagent orchestration post, diagnosis and research notes

### DIFF
--- a/content/pt/posts/como-orquestro-subagentes-autonomos-no-terminal.md
+++ b/content/pt/posts/como-orquestro-subagentes-autonomos-no-terminal.md
@@ -1,0 +1,102 @@
+---
+title: Como orquestro subagentes autônomos no terminal com Hermes, Kanban SQLite e
+  Fallback de LLMs
+description: Por dentro da arquitetura de 4 camadas, despacho via daemon launchd e
+  isolamento com git worktree para executar tarefas de desenvolvimento sem intervenção
+  humana.
+date: '2026-08-02 04:55:00'
+tags:
+- PT_BR
+- DIY
+- hermes
+- local-llm
+- automation
+- architecture
+---
+Se você já tentou deixar um agente de IA rodando em segundo plano para resolver tarefas no seu código, provavelmente esbarrou em três problemas clássicos: o agente travou a sua branch do `git`, estourou a sua cota de API no meio do processo, ou perdeu o contexto de onde tinha parado.
+
+No meu último post, contei [como aposentei R$200/mês de LLM Cloud](/pt/posts/m5-pro-48gb-hermes-local-llm-pipeline) montando um setup local com o M5 Pro e uma matriz de roteamento de modelos. Hoje quero dar um passo além e abrir as engrenagens de **como o meu agente realmente trabalha de forma autônoma**.
+
+Vou mostrar como o [Hermes Agent](https://hermes-agent.nousresearch.com/docs) orquestra subagentes em segundo plano utilizando um quadro Kanban baseado em [SQLite](https://www.sqlite.org/), tarefas encadeadas em pipeline e [git worktree](https://git-scm.com/docs/git-worktree) para nunca mais ter que parar o que estou fazendo no terminal.
+
+## A Arquitetura do Despachante: Como o Hermes Trabalha em Segundo Plano
+
+Diferente de um chat convencional onde você espera a resposta na tela, um agente agentico precisa operar de maneira assíncrona.
+
+O coração do sistema é o **Hermes Gateway**, um [daemon](/pt/notes/glossary#daemon) que roda como um serviço do [launchd](/pt/notes/glossary#launchd) no macOS. A cada 60 segundos, ele faz um *polling* no banco de dados do Kanban (`~/.hermes/kanban.db`) em busca de tarefas que estejam no estado `ready` e com um responsável designado.
+
+> **📋 Fluxo de Execução Assíncrona:**
+>
+> | Etapa | Ação realizada pelo sistema |
+> |---|---|
+> | **1. Enfileiramento** | Tarefa é criada com o padrão de pipeline (`Debug` ➔ `Fix` ➔ `Test` ➔ `PR` ➔ `Merge`) |
+> | **2. Despacho** | Gateway detecta a task em `ready` e dispara um subagente isolado (`delegate_task`) |
+> | **3. Isolamento** | Subagente cria uma `git worktree` em um diretório temporário para não tocar na branch atual |
+> | **4. Execução & Fallback** | O subagente resolve o problema alternando entre modelos (Claude CLI, Gemini, Ollama ou Local) |
+> | **5. Integração** | Executa testes, faz o push da branch, abre a PR e realiza o merge automaticamente |
+
+## O Padrão de Engenharia em 5 Etapas
+
+Para garantir que uma IA não saia alterando código de forma caótica no repositório, toda tarefa complexa no blog ou em projetos pessoais é decomposta rigorosamente em 5 sub-tarefas encadeadas:
+
+```
+1. Debug ──► 2. Fix em Worktree ──► 3. Test ──► 4. PR ──► 5. Merge e Notificação
+```
+
+Esse encadeamento é feito via dependências nativas no Kanban do Hermes. A tarefa `2. Fix` só é promovida para `ready` no momento exato em que a tarefa `1. Debug` é concluída com sucesso.
+
+Para ilustrar na prática, este é o comando que uso para criar uma sequência completa de correção:
+
+```sh
+hermes kanban create "1. Debug do problema" && \
+hermes kanban create "2. Fix em worktree" && \
+hermes kanban create "3. Testar build local" && \
+hermes kanban create "4. Enviar branch e abrir PR" && \
+hermes kanban create "5. Merge da PR e notificação"
+```
+
+E para vincular a cadeia de dependências onde cada etapa aguarda a anterior:
+
+```sh
+hermes kanban link t_debug_id t_fix_id && \
+hermes kanban link t_fix_id t_test_id && \
+hermes kanban link t_test_id t_pr_id && \
+hermes kanban link t_pr_id t_merge_id
+```
+
+## O Segredo do Isolamento: Evitando Colisões com `git worktree`
+
+Se você tem 2 ou 3 subagentes trabalhando simultaneamente no mesmo repositório, deixar todos eles editando o mesmo diretório de trabalho é uma receita certa para desastre no `git`.
+
+A solução para isso foi adotar o [git worktree](https://git-scm.com/docs/git-worktree). Em vez de fazer checkout de branches na pasta principal do projeto, cada subagente cria uma árvore de trabalho totalmente isolada em uma pasta temporária:
+
+Para criar um ambiente de trabalho limpo e isolado sem afetar a pasta principal:
+
+```sh
+git worktree add /tmp/blog-fix-branch -b feat/fix-bug main
+```
+
+O subagente trabalha, roda os testes e faz o commit dentro de `/tmp/blog-fix-branch`. Quando o trabalho termina e a PR é enviada, o worktree é destruído sem deixar rastro no meu diretório atual:
+
+Para remover a pasta temporária do worktree após o término do trabalho:
+
+```sh
+git worktree remove --force /tmp/blog-fix-branch
+```
+
+## Roteamento Dinâmico de LLMs durante a Execução
+
+A grande vantagem dessa arquitetura é que o subagente não fica travado se uma API falhar. Durante a execução da tarefa, ele utiliza uma **cadeia de contingência de 4 níveis**:
+
+1. **Claude Pro via CLI (`claude-task.sh`)**: Usado para engenharia de software pesada e refatorações complexas sem gastar créditos de API.
+2. **Gemini 3.6 Flash/Pro via [OpenRouter](/pt/notes/glossary#OpenRouter) [BYOK](/pt/notes/glossary#BYOK)**: Usado quando a tarefa exige ler repositórios inteiros utilizando a janela de contexto de 1 milhão de tokens.
+3. **Ollama Cloud (`kimi-k2.7-code` / `deepseek-v4-flash`)**: Usado para automações recorrentes e tarefas secundárias do Kanban em lote.
+4. **Local M5 Pro (`qwen3-coder-30b-local`)**: O fallback final rodando a 89 tokens/segundo no [llama.cpp](https://github.com/ggml-org/llama.cpp) com aceleração por [Metal](/pt/notes/glossary#Metal). Se a internet cair ou o cloud retornar erro 402, o subagente migra para o Mac local instantaneamente.
+
+## Considerações Finais
+
+Delegar tarefas para agentes autônomos no terminal só funciona de verdade quando você constrói trilhos claros para a IA rodar.
+
+Com a combinação de um **quadro Kanban relacional no SQLite**, **isolamento de código com `git worktree`** e uma **matriz de fallback resiliente**, consegui transformar o meu agente em um verdadeiro colega de equipe que resolve bugs, roda suítes de testes e abre PRs em segundo plano enquanto eu continuo focado em outras atividades.
+
+> Não sabe algum termo? Consulte o [Glossário](/pt/notes/glossary).

--- a/content/pt/posts/diagnostico-gargalos-fluxo-subagentes.md
+++ b/content/pt/posts/diagnostico-gargalos-fluxo-subagentes.md
@@ -1,0 +1,138 @@
+---
+title: 'Diagnóstico: gargalos e oportunidades no fluxo de subagentes'
+description: Mapeamento dos gargalos reais do fluxo de subagentes do Hermes Agent
+  e oportunidades de melhoria.
+date: '2026-08-02'
+tags:
+- PT_BR
+- diagnostico
+- hermes
+- subagentes
+- gargalo
+- performance
+- quota
+- fallback
+---
+# Diagnóstico: gargalos e oportunidades no fluxo de subagentes
+
+> Diagnóstico original gerado durante a task `t_b3b07a43`. Relacionado ao post `[[como-orquestro-subagentes-autonomos-no-terminal|Como orquestro subagentes autônomos no terminal]]` e à pesquisa `[[pesquisa-aprofundada-otimizacao-subagentes|Pesquisa Aprofundada - Otimização de Subagentes]]`.
+
+---
+
+## 1. Contexto analisado
+
+- **Post de referência:** `[[como-orquestro-subagentes-autonomos-no-terminal|Como orquestro subagentes autônomos no terminal]]`
+- **Sistema:** Hermes Agent + Kanban SQLite + launchd gateway + git worktree + fallbacks LLM
+- **Data do diagnóstico:** 2026-08-02
+
+---
+
+## 2. O que funciona conforme descrito no post
+
+| Tema | Estado real | Evidência |
+|------|-------------|-----------|
+| Gateway launchd ativo | OK | `hermes gateway status` → PID ativo, plist em `~/Library/LaunchAgents/ai.hermes.gateway.plist` |
+| Dispatcher embutido no gateway | OK | `kanban.dispatch_in_gateway: true`, log mostra `kanban dispatcher [default]: spawned=N ...` |
+| Intervalo 60s de polling | OK | `dispatch_interval_seconds: 60` em `<HERMES_HOME>/config.yaml` |
+| `git worktree` isolado | OK | Workspaces em `~/.hermes/kanban/workspaces/<task>`; tarefas de blog usam worktree do repo Quartz |
+| Pipeline Debug→Fix→Test→PR→Merge | OK | Corrente `t_b3b07a43 → t_20d010be → t_b5df03b1 → t_c631dab6 → t_1d524aab` |
+
+---
+
+## 3. Gargalos mapeados
+
+### 3.1 Fallback de LLM está incompleto (alto impacto)
+
+**Problema:** O post promete 4 níveis de fallback (Claude CLI → Gemini/OpenRouter → Ollama Cloud → Local M5 Pro). Na prática:
+
+- `fallback_providers: []` está vazio em `<HERMES_HOME>/config.yaml`.
+- Todos os modelos auxiliares (`compression`, `triage_specifier`, `kanban_decomposer`, `approval`, `monitor`, `curator`, etc.) apontam **exclusivamente** para `ollama-cloud` com `deepseek-v4-flash:0731`.
+- Provedor default `ollama-cloud` com `kimi-k2.7-code`.
+- **Não há configuração de fallback automático** entre provedores; quando ollama-cloud cai, o agente trava.
+
+**Evidência do log:**
+```
+API call failed (attempt 1/3): APIConnectionError — Provider: ollama-cloud Model: deepseek-v4-pro
+... 3 retries ...
+Final error: Connection error.
+```
+
+**Consequência:** Tarefas longas (cron, kanban auto-decompose, curator) falham em cascata se a Ollama Cloud falhar. Nenhuma rota para OpenRouter, Anthropic ou local M5 Pro está ativa.
+
+**Oportunidade:** Popular `fallback_providers`, configurar modelos auxiliares com provider secundário (ex: `openrouter`/`gemini`) e garantir que o fallback local `qwen3-coder-30b` ou `minimax-m3` seja invocado quando cloud retornar 502/503/429/Connection error.
+
+### 3.2 Iteration budget esgotado em tarefas de fix (alto impacto)
+
+**Problema:** Tarefas `2. Fix` em `running` com `consecutive_failures=1` e erro `Iteration budget exhausted (60/60)`.
+
+**Evidência:**
+```
+t_7f4407ec|running|1|Iteration budget exhausted (60/60)
+t_9869748f|running|1|Iteration budget exhausted (60/60)
+```
+
+**Causa raiz provável:** Tarefa é muito ampla para 60 iterações (`agent.max_turns: 60`). O subagente gasta dezenas de turns em patching individual de links/rotas, validações incrementais e rebuilds.
+
+**Oportunidade:**
+1. Aumentar `agent.max_turns` ou usar `max_runtime_seconds` por task.
+2. Dividir tarefas grandes de fix em sub-tarefas menores (ex: um patch por arquivo ou por idioma).
+3. Usar `goal_mode: true` com `goal_max_turns` para tarefas abertas, ou adicionar `subagent_auto_approve: true` para reduzir interrupções.
+
+### 3.3 Auto-decomposer pode gerar dependências falsas (médio impacto)
+
+**Problema:** Skill `kanban-management` documenta que `hermes kanban link` e `decompose` podem fazer o auto-decomposer ligar um pai a tasks não relacionadas, bloqueando promotion.
+
+**Consequência:** A pipeline atual depende de links manuais; se `auto_decompose: true`, pode haver interferência.
+
+**Oportunidade:** Desligar `auto_decompose` durante criação manual de chains (`hermes gateway stop`, criar links, depois restart), ou rotina de `unlink`.
+
+### 3.4 Board cresce sem limpeza de arquivados (baixo impacto)
+
+**Problema:** `kanban.db` contém 51 tarefas arquivadas e 99 done. Não há mecanismo visível de compactação/retenção.
+
+**Evidência:**
+```
+archived|51
+done|99
+running|3
+todo|10
+```
+
+**Oportunidade:** Adicionar retenção configurável (`kanban.archive_retention_days`) e rotina de `hermes kanban gc`.
+
+### 3.5 Falta visibilidade de progresso em tarefas longas (médio impacto)
+
+**Problema:** Heartbeat do worker não carrega notas de progresso por padrão; dispatcher loga apenas `spawned=N reclaimed=0 crashed=0`.
+
+**Oportunidade:** Workers de longa duração deveriam chamar `kanban_heartbeat(note=...)` a cada marco.
+
+### 3.6 Worktree requer node_modules (médio impacto)
+
+**Problema:** Em worktree de projeto Node, `node_modules` não é clonado automaticamente; builds falham se agente não rodar `npm install`.
+
+**Oportunidade:** Criar hook/tarefa inicial de bootstrap no worktree (`npm ci` ou `uv sync`) para garantir ambiente compilável.
+
+---
+
+## 4. Conclusão e recomendações priorizadas
+
+1. **Configurar fallback de LLM** — preencher `fallback_providers` e diversificar modelos auxiliares. Sem isso, a promessa do post de "fallback resiliente" não é real.
+2. **Reduzir tamanho das tarefas de fix** ou eleger `max_turns`/`goal_mode` adequados para evitar esgotamento de iterações.
+3. **Controlar auto-decompose** quando criar pipelines manualmente.
+4. **Adicionar bootstrap de dependências** ao worktree e heartbeats com notas de progresso.
+5. **Considerar GC de tarefas antigas** para manter o board enxuto.
+
+---
+
+## Referências
+
+- [[como-orquestro-subagentes-autonomos-no-terminal|Como orquestro subagentes autônomos no terminal]]
+- [[pesquisa-aprofundada-otimizacao-subagentes|Pesquisa Aprofundada - Otimização de Subagentes]]
+- `<HERMES_HOME>/config.yaml`
+- `<HERMES_HOME>/kanban.db`
+- Skill: `kanban-management` (Hermes)
+- Skill: `subagent-driven-development` (Hermes)
+
+---
+Gerado em: 2026-08-02
+Task: t_b3b07a43

--- a/content/pt/posts/pesquisa-aprofundada-otimizacao-subagentes.md
+++ b/content/pt/posts/pesquisa-aprofundada-otimizacao-subagentes.md
@@ -1,0 +1,318 @@
+---
+title: Pesquisa Aprofundada — Otimização de Subagentes no Hermes Agent
+description: Proposta de arquitetura de orquestração com controle de quota, concorrência
+  real e observabilidade para o fluxo de subagentes do Hermes Agent.
+date: '2026-08-02'
+tags:
+- PT_BR
+- research
+- hermes
+- subagents
+- orquestração
+- quota
+- concorrência
+- performance
+---
+# Pesquisa Aprofundada — Otimização de Subagentes no Hermes Agent
+
+> TL;DR: O fluxo de subagentes do Hermes Agent (gateway + dispatcher + kanban + git worktree) funciona para tarefas pequenas, mas empaca em trabalhos grandes. As causas principais são: (1) **fallback de LLM inexistente**, (2) **budget de iterações pequeno demais para fixes amplos**, (3) **auto-decompose criando dependências falsas**, (4) **falta de bootstrap de dependências no worktree**, (5) **progresso invisível em tarefas longas** e (6) **acúmulo de tarefas antigas no board**. Esta nota propõe uma arquitetura de orquestração com controle de quota, concorrência real e observabilidade.
+
+---
+
+## 1. Contexto e diagnóstico resumido
+
+A análise partiu do post `[[como-orquestro-subagentes-autonomos-no-terminal|Como orquestro subagentes autônomos no terminal]]` e do estado real do sistema em 2026-08-02. O diagnóstico completo está em `[[diagnostico-gargalos-fluxo-subagentes|Diagnóstico - gargalos no fluxo de subagentes]]`.
+
+### 1.1 Gargalos mapeados
+
+| # | Gargalo | Impacto | Causa raiz |
+|---|---------|---------|------------|
+| 1 | Fallback de LLM não configurado | Alto | `fallback_providers: []` e todos os modelos auxiliares exclusivamente em `ollama-cloud` |
+| 2 | Iteration budget esgotado (60/60) em tarefas de fix | Alto | Tarefas amplas para o limite de `max_turns` |
+| 3 | Auto-decompose gera dependências falsas | Médio | Ligação automática entre pais e tasks não relacionadas |
+| 4 | Board cresce sem GC | Baixo | 51 arquivadas + 99 done sem retenção configurável |
+| 5 | Progresso invisível em tarefas longas | Médio | Heartbeat sem notas de marco |
+| 6 | Worktree sem bootstrap de dependências | Médio | Worktree Node chega sem `node_modules` |
+
+---
+
+## 2. Arquitetura proposta
+
+O objetivo é transformar o fluxo de "um agente faz tudo em 60 turns" para "muitos agentes pequenos executando em paralelo, supervisionados por um orquestrador enxuto".
+
+### 2.1 Visão geral
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                         Gateway Hermes                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │   Kanban DB  │  │  Dispatcher  │  │  Provider Manager    │  │
+│  │  (SQLite)    │  │  (60s poll)  │  │  (fallback + quota)   │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────────┬───────────┘  │
+└─────────┼─────────────────┼─────────────────────┼───────────────┘
+          │                 │                     │
+          │                 │                     │
+┌─────────▼─────────────────▼─────────────────────▼───────────────┐
+│                      Worktree / Workspace                        │
+│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐  │
+│  │ Task fix-1  │ │ Task fix-2 │ │ Task test  │ │ Task doc   │ │
+│  │ (subagent)  │ │ (subagent) │ │ (subagent) │ │ (subagent) │ │
+│  └────────────┘ └────────────┘ └────────────┘ └────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Princípios
+
+1. **Decomposição explícita**: o usuário ou o `kanban_decomposer` define a cadeia de tasks. Auto-decompose é desligado durante criação manual.
+2. **Subagentes pequenos**: cada task cabe em no máximo 30–40 turns. Se não cabe, subdivide.
+3. **Quota por provider**: limitar chamadas simultâneas e RPM por provedor para evitar 429/503.
+4. **Fallback determinístico**: quando um provider falha, o sistema tenta o próximo em até 4 níveis.
+5. **Observabilidade obrigatória**: heartbeats com notas de progresso a cada marco.
+6. **Bootstrap automático**: worktree Node roda `npm ci`; Python roda `uv sync` antes de começar.
+
+---
+
+## 3. Otimizações de quota
+
+### 3.1 Problema atual
+
+Todos os modelos auxiliares (`compression`, `triage_specifier`, `kanban_decomposer`, `approval`, `monitor`, `curator`) estão no mesmo provider (`ollama-cloud`) e no mesmo modelo (`deepseek-v4-flash:0731`). Isso cria:
+
+- **Hot spot**: um único ponto de falha.
+- **Contenção**: todos disputam a mesma quota.
+- **Sem rotação**: não há load balancing entre provedores.
+
+### 3.2 Distribuição de carga por função
+
+| Função auxiliar | Provider primário | Provider secundário | Motivo |
+|-----------------|-------------------|---------------------|--------|
+| `compression` | `ollama-cloud` | `openrouter` | Tarefa leve, pode rodar em modelo barato |
+| `triage_specifier` | `gemini` | `ollama-cloud` | Precisa de contexto moderado, Gemini tem janela grande |
+| `kanban_decomposer` | `gemini` | `openrouter` | Gera estrutura; precisa ser confiável e barato |
+| `approval` | `openrouter` | `anthropic` | Requer qualidade de julgamento |
+| `monitor` | `ollama-cloud` | `local` | Monitoramento contínuo, pode rodar local |
+| `curator` | `anthropic` | `openrouter` | Revisão crítica de skills |
+
+> **Nota**: nomes de provider são exemplos. O config.yaml real do usuário (2026-08-02) só possui `ollama-cloud` e `ollama-launch` configurados. Antes de ativar fallbacks para `openrouter`, `anthropic` ou `gemini`, é necessário adicionar esses providers com `api_key`/`base_url` válidos. O único fallback local disponível hoje é `ollama-launch` na máquina M5 Pro (`http://192.168.1.13:8131` não aparece no config; o modelo local é acessado via `ollama-launch` em `http://127.0.0.1:11434/v1` ou similar).
+
+### 3.3 Configuração de `fallback_providers`
+
+Exemplo de configuração no `config.yaml`:
+
+```yaml
+providers:
+  ollama-cloud:
+    base_url: https://ollama.com/v1
+    api_key: ollama
+  ollama-launch:
+    api: http://127.0.0.1:11434/v1
+  # ⚠️ openrouter, anthropic e gemini precisam ser adicionados no config.yaml real antes de serem usados como fallback
+  openrouter:
+    api_key: ${OPENROUTER_API_KEY}
+  anthropic:
+    api_key: ${ANTHROPIC_API_KEY}
+  gemini:
+    api_key: ${GEMINI_API_KEY}
+
+llm:
+  provider: ollama-cloud
+  model: kimi-k2.7-code
+  fallback_providers:
+    - provider: openrouter
+      model: google/gemini-2.5-flash-preview-05-20
+    - provider: anthropic
+      model: claude-sonnet-4-20250514
+    - provider: ollama-launch
+      model: qwen3-coder-30b
+```
+
+### 3.4 Quotas e concorrência
+
+Proposta de adicionar um bloco de rate-limiting por provider:
+
+```yaml
+llm:
+  quota:
+    ollama-cloud:
+      max_concurrent: 4
+      rpm: 60
+      tpm: 40000
+    openrouter:
+      max_concurrent: 6
+      rpm: 120
+      tpm: 80000
+    anthropic:
+      max_concurrent: 3
+      rpm: 30
+      tpm: 20000
+    local:
+      max_concurrent: 2
+      rpm: 30
+      tpm: 20000
+```
+
+O dispatcher respeita essas quotas antes de spawnar novos subagentes. Se a quota está cheia, a task fica na fila `ready` até liberar.
+
+---
+
+## 4. Melhorias de concorrência
+
+### 4.1 Divisão de tarefas grandes
+
+Uma tarefa de fix com 140 links quebrados não deve ser uma task só. Modelo de split:
+
+| Tamanho do problema | Estratégia | Exemplo |
+|---------------------|------------|---------|
+| 1 arquivo pequeno | 1 task direta | `fix typo em about.md` |
+| 1 arquivo médio | 1 task com `goal_mode: true` | `refatorar componente X` |
+| Vários arquivos | 1 task por arquivo ou por idioma | `fix links pt`, `fix links en` |
+| Muitos itens idênticos | batch job interno | `corrigir 140 wikilinks` pode ser 1 agente iterando, mas com `max_turns: 120` |
+
+Para o caso específico dos 140 links quebrados, a estratégia recomendada é:
+
+1. Task mãe: "Corrigir links internos quebrados".
+2. Subtasks por idioma: `fix-pt`, `fix-en`, `fix-protocols`.
+3. Cada subtask tem `max_turns: 40` e `max_runtime_seconds: 1800`.
+4. Task mãe só conclui quando todas as filhas estão `done`.
+
+### 4.2 Goal mode para tarefas abertas
+
+Tarefas de pesquisa ou debugging se beneficiam de `goal_mode: true`:
+
+```yaml
+goal_mode: true
+goal_max_turns: 40
+max_runtime_seconds: 3600
+```
+
+Isso permite que um juiz auxiliar decida se a task terminou, em vez de esgotar o budget do agente principal.
+
+### 4.3 Subagentes auto-aprovados
+
+Para tarefas repetitivas e de baixo risco (formatação, links, testes automatizados), ativar:
+
+```yaml
+subagent_auto_approve: true
+```
+
+Isso economiza turns gastos em pedidos de aprovação.
+
+### 4.4 Pipeline paralela padrão
+
+Para novos fluxos de trabalho, adotar o pipeline:
+
+```
+1. Debug  → 2. Fix A / Fix B / Fix C  → 3. Test  → 4. PR  → 5. Merge
+```
+
+Onde `Fix A`, `Fix B` e `Fix C` são tasks irmãs executadas em paralelo.
+
+---
+
+## 5. Observabilidade e progresso
+
+### 5.1 Heartbeat com notas
+
+Toda task com expectativa de duração > 10 minutos deve emitir:
+
+```python
+kanban_heartbeat(note="Milestone: 50/140 links corrigidos (pt)")
+```
+
+Recomendação de frequência:
+
+| Duração esperada | Frequência de heartbeat |
+|------------------|-------------------------|
+| < 10 min | Apenas no início/fim |
+| 10–30 min | A cada 10 min ou marco |
+| 30–60 min | A cada 15 min ou marco |
+| > 60 min | A cada 20 min + marcos |
+
+### 5.2 Métricas no dispatcher
+
+Proposta de enriquecer o log do dispatcher com:
+
+- `spawned=N` (já existe)
+- `queued=N` (tasks `ready` esperando quota)
+- `running_by_provider={ollama-cloud:3, openrouter:2}`
+- `reclaimed=0 crashed=0` (já existe)
+- `avg_task_duration=420s`
+
+Isso permite detectar filas crescentes e gargalos de provider.
+
+---
+
+## 6. Bootstrap de worktree
+
+### 6.1 Problema
+
+Worktree adicionado via `git worktree add` não traz `node_modules`. Subagente chega em um projeto Node sem dependências instaladas e gasta turns descobrindo isso.
+
+### 6.2 Solução
+
+Adicionar hook de preparação automática no início de toda task que usa worktree:
+
+| Tipo de projeto | Comando de bootstrap | Observação |
+|-----------------|----------------------|------------|
+| Node / npm | `npm ci` ou `npm install` | Necessário quando `node_modules` não está no worktree |
+| Node / pnpm | `pnpm install --frozen-lockfile` | Preferir se lockfile existir |
+| Python / uv | `uv sync` | O `uv` já está instalado no host |
+| Python / pip | `python -m pip install -r requirements.txt` | Fallback se uv não disponível |
+| Rust | `cargo build` | Compila dependências no workspace |
+
+### 6.3 Onde colocar
+
+A skill `kanban-management` ou uma skill dedicada (`worktree-bootstrap`) pode oferecer um helper que o dispatcher executa antes de delegar para o subagente. Alternativamente, o agente principal faz o bootstrap no primeiro turn.
+
+---
+
+## 7. GC e retenção do board
+
+### 7.1 Política proposta
+
+```yaml
+kanban:
+  archive_retention_days: 90
+  done_retention_days: 30
+  gc_interval_hours: 24
+```
+
+### 7.2 Efeito
+
+- Tarefas `done` com mais de 30 dias são movidas para `archived`.
+- Tarefas `archived` com mais de 90 dias são apagadas do SQLite (ou exportadas para CSV de backup).
+- Reduz bloat do board e acelera queries do dispatcher.
+
+---
+
+## 8. Recomendações priorizadas
+
+1. **Configurar fallback_providers e distribuir modelos auxiliares** — sem isso, o sistema não é resiliente.
+2. **Aumentar max_turns / usar goal_mode para tarefas grandes** — evitar esgotamento.
+3. **Subdividir fixes amplos** — um patch por arquivo/idioma, não um agente para tudo.
+4. **Desligar auto-decompose durante criação manual de chains** — evitar dependências falsas.
+5. **Adicionar bootstrap de dependências no worktree** — economizar turns e evitar erros de build.
+6. **Mandar heartbeats com notas de progresso** — melhorar observabilidade.
+7. **Adicionar política de retenção e GC** — manter board enxuto.
+
+---
+
+## 9. Próximos passos sugeridos
+
+- Task filha `t_c631dab6`: salvar arquivos de pesquisa/documentação na branch isolada e abrir PR se aplicável.
+- Task seguinte `t_1d524aab`: implementar configuração de fallback e quota no `config.yaml`.
+
+---
+
+## Referências
+
+- [[como-orquestro-subagentes-autonomos-no-terminal|Como orquestro subagentes autônomos no terminal]]
+- [[diagnostico-gargalos-fluxo-subagentes|Diagnóstico - gargalos no fluxo de subagentes]]
+- `<HERMES_HOME>/config.yaml`
+- `<HERMES_HOME>/kanban.db`
+- Skill: `kanban-management` (Hermes)
+- Skill: `subagent-driven-development` (Hermes)
+
+---
+Gerado em: 2026-08-02
+Task: t_20d010be


### PR DESCRIPTION
Adiciona o post original sobre orquestração de subagentes, o diagnóstico de gargalos e a pesquisa aprofundada de otimização no blog.\n\nArquivos incluídos:\n- `content/pt/posts/como-orquestro-subagentes-autonomos-no-terminal.md`\n- `content/pt/posts/diagnostico-gargalos-fluxo-subagentes.md`\n- `content/pt/posts/pesquisa-aprofundada-otimizacao-subagentes.md`\n\nBuild local passou: `npm run build` → 57 arquivos, 161 emitidos.