### PR TITLE
fix(mobile): improve mobile header layout and explorer behavior

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -30,7 +30,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.TagList(),
   ],
   left: [
-    Component.DesktopOnly(Component.ProfileImage()),
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({
@@ -57,7 +56,6 @@ export const defaultContentPageLayout: PageLayout = {
 export const defaultListPageLayout: PageLayout = {
   beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
   left: [
-    Component.DesktopOnly(Component.ProfileImage()),
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -78,27 +78,6 @@ export default ((userOpts?: Partial<Options>) => {
       >
         <button
           type="button"
-          class="explorer-toggle mobile-explorer hide-until-loaded"
-          data-mobile={true}
-          aria-controls={id}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="lucide-menu"
-          >
-            <line x1="4" x2="20" y1="12" y2="12" />
-            <line x1="4" x2="20" y1="6" y2="6" />
-            <line x1="4" x2="20" y1="18" y2="18" />
-          </svg>
-        </button>
-        <button
-          type="button"
           class="title-button explorer-toggle desktop-explorer"
           data-mobile={false}
           aria-expanded={true}
@@ -122,6 +101,7 @@ export default ((userOpts?: Partial<Options>) => {
         <div id={id} class="explorer-content" aria-expanded={false} role="group">
           <OverflowList class="explorer-ul" />
         </div>
+        <div class="explorer-overlay explorer-toggle"></div>
         <template id="template-file">
           <li>
             <a href="#"></a>

--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -7,17 +7,132 @@ const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzCompo
   const title = cfg?.pageTitle ?? i18n(cfg.locale).propertyDefaults.title
   const baseDir = pathToRoot(fileData.slug!)
   return (
-    <h2 class={classNames(displayClass, "page-title")}>
-      <a href={baseDir}>{title}</a>
-    </h2>
+    <div class={classNames(displayClass, "page-title-container")}>
+      <button
+        type="button"
+        class="explorer-toggle mobile-explorer hide-until-loaded"
+        data-mobile={true}
+        aria-controls="explorer-content"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="lucide-menu"
+        >
+          <line x1="4" x2="20" y1="12" y2="12" />
+          <line x1="4" x2="20" y1="6" y2="6" />
+          <line x1="4" x2="20" y1="18" y2="18" />
+        </svg>
+      </button>
+      <div class="profile-image-container">
+        <a href={baseDir}>
+          <img src="https://github.com/Calebe94.png" alt="Calebe94" />
+        </a>
+      </div>
+      <h2 class="page-title">
+        <a href={baseDir}>{title}</a>
+      </h2>
+    </div>
   )
 }
 
 PageTitle.css = `
+.page-title-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  max-width: 100%; /* Prevent container from expanding past sidebar width */
+}
+
 .page-title {
   font-size: 1.75rem;
   margin: 0;
   font-family: var(--titleFont);
+  white-space: nowrap; /* Prevent title from wrapping and squishing the image */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1; /* Allow the text to shrink and trigger the ellipsis if there's no space */
+  min-width: 0; /* Important for ellipsis to work in a flex container */
+}
+
+/* Base style (desktop and default) hides the explorer toggle button */
+.page-title-container .mobile-explorer {
+  display: none;
+}
+
+.profile-image-container {
+  display: flex;
+  margin-bottom: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-image-container a {
+  display: block;
+  line-height: 0;
+  border-radius: 50%;
+  overflow: hidden; /* Forces any contained elements (like the image) to be clipped to the 50% border radius */
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  flex-shrink: 0; /* Prevents the container from shrinking when text is too long */
+  -webkit-mask-image: -webkit-radial-gradient(white, black); /* Safari fix for border-radius on images */
+}
+
+.profile-image-container img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--secondary);
+  transition: border-color 0.2s ease;
+  display: block;
+  box-sizing: border-box; /* Ensure border size doesn't change the size of the element */
+  margin: 0;
+  padding: 0;
+}
+
+.profile-image-container img:hover {
+  border-color: var(--tertiary);
+}
+
+@media all and (min-width: 768px) {
+  .page-title-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .page-title {
+    white-space: normal; /* Allow wrapping on desktop */
+  }
+
+  .profile-image-container a {
+    width: 80px;
+    height: 80px;
+    min-width: 80px;
+    min-height: 80px;
+  }
+
+  .profile-image-container img {
+    border-width: 3px;
+  }
+}
+
+@media all and (max-width: 800px) {
+  /* On mobile, lay out as a horizontal row and show the explorer toggle button */
+  .page-title-container {
+    flex-direction: row;
+  }
+
+  .page-title-container .mobile-explorer {
+    display: flex;
+  }
 }
 `
 

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -20,9 +20,16 @@ type FolderState = {
 }
 
 let currentExplorerState: Array<FolderState>
+
 function toggleExplorer(this: HTMLElement) {
-  const nearestExplorer = this.closest(".explorer") as HTMLElement
+  // If the mobile button was clicked, find the actual explorer container
+  let nearestExplorer = this.closest(".explorer")
+  if (!nearestExplorer) {
+    // If it's the global mobile toggle, find the explorer in the page
+    nearestExplorer = document.querySelector(".explorer")
+  }
   if (!nearestExplorer) return
+  
   const explorerCollapsed = nearestExplorer.classList.toggle("collapsed")
   nearestExplorer.setAttribute(
     "aria-expanded",
@@ -233,13 +240,46 @@ async function setupExplorer(currentSlug: FullSlug) {
     }
 
     // Set up event handlers
-    const explorerButtons = explorer.getElementsByClassName(
-      "explorer-toggle",
-    ) as HTMLCollectionOf<HTMLElement>
-    for (const button of explorerButtons) {
+    // The mobile button is now in PageTitle, so we look for it globally
+    const explorerButtons = document.querySelectorAll(
+      ".explorer-toggle",
+    )
+    for (const button of Array.from(explorerButtons)) {
       button.addEventListener("click", toggleExplorer)
       window.addCleanup(() => button.removeEventListener("click", toggleExplorer))
     }
+
+    // Set up background click to close
+    const setupBackgroundClick = () => {
+      const handleClick = (e: MouseEvent) => {
+        const target = e.target as HTMLElement
+        const isMobile = window.innerWidth <= 800
+        const isExplorerOpen = !explorer.classList.contains("collapsed")
+        
+        if (isMobile && isExplorerOpen) {
+          // If clicked outside the explorer content and not on the toggle button
+          const explorerContent = explorer.querySelector(".explorer-content")
+          const isOutsideExplorer = explorerContent && !explorerContent.contains(target)
+          const isOverlay = target.classList.contains('explorer-overlay')
+          
+          if (isOutsideExplorer && isOverlay) {
+            const toggleFn = toggleExplorer as any
+            const fakeEvent = new Event("click")
+            // Find the global explorer element
+            const globalExplorer = document.querySelector(".explorer")
+            if (globalExplorer) {
+              Object.defineProperty(fakeEvent, 'target', {writable: false, value: globalExplorer})
+              toggleFn.call(globalExplorer, fakeEvent)
+            }
+          }
+        }
+      }
+      
+      document.addEventListener("click", handleClick)
+      // @ts-ignore
+      window.addCleanup(() => document.removeEventListener("click", handleClick))
+    }
+    setupBackgroundClick()
 
     // Set up folder click handlers
     if (opts.folderClickBehavior === "collapse") {
@@ -273,12 +313,13 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
   const currentSlug = e.detail.url
   await setupExplorer(currentSlug)
 
-  // if mobile hamburger is visible, collapse by default
+  // On page load, ALWAYS collapse the explorer if we are on mobile
   for (const explorer of document.getElementsByClassName("explorer")) {
-    const mobileExplorer = explorer.querySelector(".mobile-explorer")
+    const mobileExplorer = document.querySelector(".mobile-explorer")
     if (!mobileExplorer) return
 
-    if (mobileExplorer.checkVisibility()) {
+    // Using window.innerWidth as a more reliable mobile check
+    if (window.innerWidth <= 800) {
       explorer.classList.add("collapsed")
       explorer.setAttribute("aria-expanded", "false")
 

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -3,22 +3,24 @@
 @media all and ($mobile) {
   .page > #quartz-body {
     // Shift page position when toggling Explorer on mobile.
-    & > :not(.sidebar.left:has(.explorer)) {
+    & > :not(.sidebar.left) {
       transition: transform 300ms ease-in-out;
     }
 
-    &.lock-scroll > :not(.sidebar.left:has(.explorer)) {
+    &.lock-scroll > :not(.sidebar.left) {
       transform: translateX(100%);
       transition: transform 300ms ease-in-out;
     }
 
     // Sticky top bar (stays in place when scrolling down on mobile).
-    .sidebar.left:has(.explorer) {
+    .sidebar.left {
       box-sizing: border-box;
       position: sticky;
+      top: 0;
       background-color: var(--light);
       padding: 1rem 0 1rem 0;
       margin: 0;
+      z-index: 102; /* Ensure the header is above the absolute explorer menu */
     }
 
     .hide-until-loaded ~ .explorer-content {
@@ -69,7 +71,8 @@
 
   @media all and ($mobile) {
     button.mobile-explorer {
-      display: flex;
+      /* Handled in PageTitle globally */
+      display: none;
     }
 
     button.desktop-explorer {
@@ -108,6 +111,25 @@ button.desktop-explorer {
     font-size: 1rem;
     display: inline-block;
     margin: 0;
+  }
+}
+
+.mobile-explorer {
+  margin: 0;
+  padding: 10px;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+
+  .lucide-menu {
+    stroke: var(--darkgray);
+    width: 28px;
+    height: 28px;
   }
 }
 
@@ -245,7 +267,7 @@ li:has(> .folder-outer:not(.open)) > .folder-container > svg {
 .explorer {
   @media all and ($mobile) {
     &.collapsed {
-      flex: 0 0 34px;
+      flex: 0 0 auto;
 
       & > .explorer-content {
         transform: translateX(-100%);
@@ -254,7 +276,7 @@ li:has(> .folder-outer:not(.open)) > .folder-container > svg {
     }
 
     &:not(.collapsed) {
-      flex: 0 0 34px;
+      flex: 0 0 auto;
 
       & > .explorer-content {
         transform: translateX(0);
@@ -265,39 +287,24 @@ li:has(> .folder-outer:not(.open)) > .folder-container > svg {
     .explorer-content {
       box-sizing: border-box;
       z-index: 100;
-      position: absolute;
+      position: fixed; /* Instead of absolute to take up whole screen relative to viewport */
       top: 0;
       left: 0;
       margin-top: 0;
       background-color: var(--light);
       max-width: 100%;
-      width: 100%;
+      width: 80%; /* Don't take the full width to show the click-to-close area */
+      max-width: 400px; /* Cap width for larger mobile devices */
       transform: translateX(-100%);
       transition:
         transform 200ms ease,
         visibility 200ms ease;
       overflow: hidden;
-      padding: 4rem 0 2rem 0;
+      padding: 5rem 1rem 2rem 1rem; /* Added padding-top to not be under the sticky header */
       height: 100dvh;
       max-height: 100dvh;
       visibility: hidden;
-    }
-
-    .mobile-explorer {
-      margin: 0;
-      padding: 10px; // Aumentado para melhor touch
-      z-index: 101;
-      width: 48px;
-      height: 48px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      .lucide-menu {
-        stroke: var(--darkgray);
-        width: 28px;
-        height: 28px;
-      }
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.2); /* Add shadow to distinguish from background */
     }
   }
 }
@@ -307,5 +314,27 @@ li:has(> .folder-outer:not(.open)) > .folder-container > svg {
     .explorer-content > .explorer-ul {
       overscroll-behavior: contain;
     }
+  }
+}
+
+/* Background overlay when mobile explorer is open */
+.explorer-overlay {
+  display: none;
+}
+
+@media all and ($mobile) {
+  .explorer:not(.collapsed) ~ .explorer-overlay,
+  .explorer:not(.collapsed) .explorer-overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 99; /* Below the explorer (100) but above everything else */
+    pointer-events: auto; /* Capture clicks to close */
+    transition: opacity 200ms ease;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
## Description

This PR improves the mobile header layout and the Quartz explorer sidebar behavior on mobile devices.

### Changes
- **Header Restructuring:** Moved the mobile explorer toggle button into the `PageTitle` component for a cleaner horizontal layout (Hamburger → Profile Image → Title).
- **Profile Image Fixes:** Ensured the avatar is a perfect circle (40x40px on mobile, 80x80px on desktop) and prevents the title text from wrapping or overlapping it using flex constraints and text truncation.
- **Drawer Overlay:** Added a darkened background overlay when the mobile explorer is open. Tapping the overlay (outside the explorer) now intuitively closes the menu.
- **Default State:** Ensured the explorer is always collapsed by default on mobile page load to prioritize content visibility.

### Breaking Change
The mobile explorer toggle button has been moved from the `Explorer` component to the `PageTitle` component. This may require updates if there is external custom styling.